### PR TITLE
Set settings.copyright correctly.

### DIFF
--- a/src/bundle/mod.rs
+++ b/src/bundle/mod.rs
@@ -34,9 +34,10 @@ pub fn bundle_project(settings: Settings) -> Result<Vec<PathBuf>, Box<Error + Se
 pub fn bundle_project(settings: Settings) -> Result<Vec<PathBuf>, Box<Error + Send + Sync>> {
     match settings.package_type {
         None => {
-            deb_bundle::bundle_project(&settings).and_then(|deb_path| {
-                let rpm_path = try!(rpm_bundle::bundle_project(&settings));
-                Ok(deb_path.extend(rpm_path))
+            deb_bundle::bundle_project(&settings).and_then(|mut deb_path| {
+                let mut rpm_path = try!(rpm_bundle::bundle_project(&settings));
+                deb_path.append(&mut rpm_path);
+                Ok(deb_path)
             })
         }
         Some(PackageType::Deb) => deb_bundle::bundle_project(&settings),

--- a/src/main.rs
+++ b/src/main.rs
@@ -199,14 +199,14 @@ impl Settings {
                 "version" => {
                     settings.version_str = Some(simple_parse!(String,
                                                               value,
-                                                              "Invalid format for bundle identifier value in \
+                                                              "Invalid format for version value in \
                                                                Bundle.toml: Expected string, found {:?}"))
                 }
                 "copyright" => {
-                    settings.version_str = Some(simple_parse!(String,
-                                                              value,
-                                                              "Invalid format for copyright notice in \
-                                                               Bundle.toml: Expected string, found {:?}"))
+                    settings.copyright = Some(simple_parse!(String,
+                                                            value,
+                                                            "Invalid format for copyright notice in \
+                                                             Bundle.toml: Expected string, found {:?}"))
                 }
                 "icon" => {
                     let icon_path = simple_parse!(String, value,


### PR DESCRIPTION
This fixes a couple typos in `main.rs`, including one that caused the "copyright" field in Bundle.toml to set `settings.version_str` rather than `settings.copyright`.