### PR TITLE
Automatically convert icon(s) to ICNS file for OSX bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 .DS_Store
+*~

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,8 @@ name = "cargo-bundle"
 version = "0.0.0"
 dependencies = [
  "clap 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "icns 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "image 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "plist 0.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -51,6 +53,116 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "deque"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "enum_primitive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "euclid"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "heapsize 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "flate2"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miniz-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gcc"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "gif"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "color_quant 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lzw 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "glob"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "heapsize"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "icns"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "png 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "image"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "enum_primitive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gif 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jpeg-decoder 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-iter 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-rational 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "png 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "inflate"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "jpeg-decoder"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-rational 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,6 +177,25 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "log"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lzw"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "miniz-sys"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "num"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,6 +203,17 @@ dependencies = [
  "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-iter 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -92,9 +234,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-rational"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-bigint 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "num_cpus"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "plist"
@@ -106,6 +267,36 @@ dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "xml-rs 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "png"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "inflate 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-iter 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rayon"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ description = "Wrap rust executables in OS-specific app bundles"
 
 [dependencies]
 clap = "^2"
+icns = "^0.2"
+image = "^0.10"
 plist = "0.*"
 toml = "^0.1"
 walkdir = "^0.1"

--- a/Readme.md
+++ b/Readme.md
@@ -31,7 +31,10 @@ If you would like to bundle a release build, you must add the `--release` flag t
            your `Cargo.toml` file.
  * `identifier`: [REQUIRED] Unique identifier for your application. This is a simple string, but it may change so that
                  you can specify it for individual platforms.
- * `icon` : [REQUIRED] The icon used for your application (Unimplemented). TODO(burtonageo): image formats?
+ * `icon`: [REQUIRED] The icon used for your application.  This can either be a single file path (string), or an array
+           of file paths (with images in various sizes/formats); `cargo-bundle` will automatically convert between
+           image formats as necessary for different platforms.  Supported formats include ICNS, ICO, PNG, and anything
+           else that can be decoded by the [`image`](https://crates.io/crates/image) crate.
  * `version`: [OPTIONAL] The version of the application. If this is not present, then it will use the `version`
               value from your `Cargo.toml` file.
  * `resources`: [OPTIONAL] List of files or directories which will be copied to the resources section of the
@@ -46,6 +49,7 @@ If you would like to bundle a release build, you must add the `--release` flag t
 
 name = "ExampleApplication"
 identifier = "com.doe.exampleapplication"
+icon = ["32x32.png", "128x128.png", "128x128@2x.png"]
 version = "1.0.0"
 resources = ["assets", "configuration", "secrets/public_key.txt"]
 copyright = "Copyright (c) Jane Doe 2016. All rights reserved."

--- a/src/bundle/osx_bundle.rs
+++ b/src/bundle/osx_bundle.rs
@@ -1,9 +1,11 @@
 use Settings;
+use icns;
+use image::{self, GenericImage};
 use std::error::Error;
 use std::ffi::OsStr;
 use std::fs::{self, File, create_dir_all};
 use std::io::prelude::*;
-use std::io;
+use std::io::{self, BufWriter};
 use std::path::{Path, PathBuf};
 use std::marker::{Send, Sync};
 use walkdir::WalkDir;
@@ -18,6 +20,13 @@ pub fn bundle_project(settings: &Settings) -> Result<Vec<PathBuf>, Box<Error + S
     let mut bundle_directory = app_bundle_path.clone();
     bundle_directory.push("Contents");
     try!(create_dir_all(&bundle_directory));
+
+    let mut resources_dir = bundle_directory.clone();
+    resources_dir.push("Resources");
+
+    let bundle_icon_file: Option<PathBuf> = try!(create_icns_file(&settings.bundle_name,
+                                                                  &resources_dir,
+                                                                  &settings.icon_files));
 
     let mut plist = try!({
         let mut f = bundle_directory.clone();
@@ -71,10 +80,10 @@ pub fn bundle_project(settings: &Settings) -> Result<Vec<PathBuf>, Box<Error + S
                             </dict>\n\
                             </plist>",
                            bin_name,
-                           settings.icon_file.as_ref()
-                                             .and_then(|p| p.file_name())
-                                             .and_then(OsStr::to_str)
-                                             .unwrap_or("???"),
+                           bundle_icon_file.as_ref()
+                                           .and_then(|p| p.file_name())
+                                           .and_then(OsStr::to_str)
+                                           .unwrap_or("???"),
                            settings.bundle_name,
                            settings.version_str.as_ref().unwrap_or(&settings.cargo_settings.version),
                            settings.identifier,
@@ -83,24 +92,11 @@ pub fn bundle_project(settings: &Settings) -> Result<Vec<PathBuf>, Box<Error + S
     try!(plist.write_all(&contents.into_bytes()[..]));
     try!(plist.sync_all());
 
-    let mut resources_dir = bundle_directory.clone();
-    resources_dir.push("Resources");
-
-    if !settings.resource_files.is_empty() || settings.icon_file.is_some() {
+    if !settings.resource_files.is_empty() {
         try!(create_dir_all(&resources_dir));
-    }
 
-    if resources_dir.exists() {
         for res_path in &settings.resource_files {
             try!(copy_path(&res_path, &resources_dir));
-        }
-
-        if let Some(ref icon_file) = settings.icon_file {
-            let mut bundle_icon_file = resources_dir.clone();
-            // icon_file has been verified to be a file in Settings::new
-            bundle_icon_file.push(icon_file.file_name().unwrap());
-            try!(File::create(bundle_icon_file.clone()));
-            try!(fs::copy(&icon_file, &bundle_icon_file));
         }
     }
 
@@ -141,4 +137,81 @@ fn copy_path(from: &Path, to: &Path) -> Result<(), io::Error> {
     }
 
     Ok(())
+}
+
+/// Given a list of icon files, try to produce an ICNS file in the resources
+/// directory and return the path to it.  Returns `Ok(None)` if no usable icons
+/// were provided.
+fn create_icns_file(bundle_name: &String,
+                    resources_dir: &PathBuf,
+                    icon_paths: &Vec<PathBuf>)
+                    -> Result<Option<PathBuf>, Box<Error + Send + Sync>> {
+    if icon_paths.is_empty() {
+        return Ok(None);
+    }
+
+    // If one of the icon files is already an ICNS file, just use that.
+    if let Some(icns_path) = icon_paths.iter().find(|path| path.extension() == Some(OsStr::new("icns"))) {
+        let mut dest_path = resources_dir.to_path_buf();
+        // icns_path has been verified to be a file in Settings::new
+        dest_path.push(icns_path.file_name().unwrap());
+        try!(create_dir_all(resources_dir));
+        try!(fs::copy(&icns_path, &dest_path));
+        return Ok(Some(dest_path));
+    }
+
+    // Otherwise, read available images and pack them into a new ICNS file.
+    let mut family = icns::IconFamily::new();
+    for icon_path in icon_paths {
+        let icon = try!(image::open(icon_path));
+        let density = if is_retina(icon_path) { 2 } else { 1 };
+        // Try to add this image to the icon family.  Ignore images whose sizes
+        // don't map to any ICNS icon type; print warnings and skip images that
+        // fail to encode.
+        if let Some(icon_type) = icns::IconType::from_pixel_size_and_density(icon.width(), icon.height(), density) {
+            if !family.has_icon_with_type(icon_type) {
+                let icon = try!(make_icns_image(icon));
+                family.add_icon_with_type(&icon, icon_type).unwrap();
+            }
+        }
+        // TODO: If none of the icons are of usable sizes, we could also use
+        // the image crate to scale icons to the appropriate sizes.
+    }
+    if !family.is_empty() {
+        try!(create_dir_all(resources_dir));
+        let mut dest_path = resources_dir.clone();
+        dest_path.push(bundle_name);
+        dest_path.set_extension("icns");
+        let icns_file = BufWriter::new(try!(File::create(&dest_path)));
+        try!(family.write(icns_file));
+        return Ok(Some(dest_path));
+    }
+
+    Err(Box::from("No usable icon files found."))
+}
+
+/// Converts an image::DynamicImage into an icns::Image.
+fn make_icns_image(img: image::DynamicImage) -> io::Result<icns::Image> {
+    let pixel_format = match img.color() {
+        image::ColorType::RGBA(8) => icns::PixelFormat::RGBA,
+        image::ColorType::RGB(8) => icns::PixelFormat::RGB,
+        image::ColorType::GrayA(8) => icns::PixelFormat::GrayAlpha,
+        image::ColorType::Gray(8) => icns::PixelFormat::Gray,
+        _ => {
+            let msg = format!("unsupported ColorType: {:?}", img.color());
+            return Err(io::Error::new(io::ErrorKind::InvalidData, msg));
+        }
+    };
+    icns::Image::from_data(pixel_format, img.width(), img.height(), img.raw_pixels())
+}
+
+/// Returns true if the path has a filename indicating that it is a high-desity
+/// "retina" icon.  Specifically, returns true the the file stem ends with
+/// "@2x" (a convention specified by the [Apple developer docs](
+/// https://developer.apple.com/library/mac/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/Optimizing/Optimizing.html)).
+pub fn is_retina(path: &Path) -> bool {
+    path.file_stem()
+        .and_then(OsStr::to_str)
+        .map(|stem| stem.ends_with("@2x"))
+        .unwrap_or(false)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 #[macro_use]
 extern crate clap;
+extern crate icns;
+extern crate image;
 extern crate plist;
 extern crate toml;
 extern crate walkdir;
@@ -71,7 +73,7 @@ impl CargoSettings {
 
         for (name, value) in cargo_info {
             match (&name[..], value) {
-                ("package", Value::Table(table))  => {
+                ("package", Value::Table(table)) => {
                     for (name, value) in table {
                         match &name[..] {
                             "name" => {
@@ -141,7 +143,7 @@ pub struct Settings {
     pub version_str: Option<String>,
     pub resource_files: Vec<PathBuf>,
     pub bundle_script: Option<PathBuf>,
-    pub icon_file: Option<PathBuf>,
+    pub icon_files: Vec<PathBuf>,
     pub copyright: Option<String>
 }
 
@@ -159,7 +161,7 @@ impl Settings {
             version_str: None,
             resource_files: vec![],
             bundle_script: None,
-            icon_file: None,
+            icon_files: vec![],
             copyright: None
         };
 
@@ -210,14 +212,23 @@ impl Settings {
                                                              Bundle.toml: Expected string, found {:?}"))
                 }
                 "icon" => {
-                    let icon_path = simple_parse!(String, value,
-                                                  "Invalid format for bundle identifier value in \
-                                                   Bundle.toml: Expected string, found {:?}");
-                    let icon_path = PathBuf::from(icon_path);
-                    if !icon_path.is_file() {
-                        return Err(Box::from("The Icon attribute must point to a file"));
-                    }
-                    settings.icon_file = Some(icon_path);
+                    settings.icon_files = match value {
+                        Value::String(icon_path) => {
+                            let icon_path = PathBuf::from(icon_path);
+                            if !icon_path.is_file() {
+                                return Err(Box::from("The icon attribute must point to a file"));
+                            }
+                            vec![icon_path]
+                        }
+                        Value::Array(icon_paths) => try!(parse_resource_files(icon_paths)),
+                        _ => {
+                            let msg = format!("Invalid format for bundle icon in \
+                                               Bundle.toml: Expected string or array, \
+                                               found {:?}",
+                                              value);
+                            return Err(Box::from(msg));
+                        }
+                    };
                 }
                 "resources" => {
                     let files = simple_parse!(Array,


### PR DESCRIPTION
This change does a couple things:
* Allows the `icon` field in `Bundle.toml` to be an array of strings (or a single string, as before), so you can provide multiple sizes/formats of icon.  That means that `Settings` now stores a `Vec` of icon paths rather than a single icon path.
* Adds icon conversion support for OSX bundles.  If an ICNS file is provided, it uses that; otherwise it reads in the provided images(s) and packs them into an ICNS file.  High-DPI icons are supported.

Caveats:
* Using the `image` crate (which provides conversions from various image formats) does add a bunch of extra transitive dependencies for all the image formats it supports.  If this is a concern, we could set the `features` for that create to only pull dependencies for the formats we need most (mostly PNG and ICO, probably).  But if it's not a concern, then we get to support converting from lots of image formats (e.g. JPEG, GIF, BMP, TIFF) basically for free.
* This change doesn't yet support icon conversions for deb packages.  I'm working on it, but I'm not quite done yet, and also I didn't want this pull request to get too big and unwieldy to review.  (-: