### PR TITLE
Add config fields for short and long descriptions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -42,18 +42,26 @@ If you would like to bundle a release build, you must add the `--release` flag t
  * `script`: [OPTIONAL] This is a reserved field; at the moment it is not used for anything, but may be used to
              run scripts while packaging the bundle (e.g. download files, compress and encrypt, etc.).
  * `copyright`: [OPTIONAL] This contains a copyright string associated with your application.
+ * `short_description`: [OPTIONAL] A short, one-line description of the application. If this is not present, then it
+                        will use the `description` value from your `Cargo.toml` file.
+ * `long_description`: [OPTIONAL] A longer, multi-line description of the application.
 
 ### Example `Bundle.toml`:
 
 ```toml
-
 name = "ExampleApplication"
 identifier = "com.doe.exampleapplication"
 icon = ["32x32.png", "128x128.png", "128x128@2x.png"]
 version = "1.0.0"
 resources = ["assets", "configuration", "secrets/public_key.txt"]
 copyright = "Copyright (c) Jane Doe 2016. All rights reserved."
-
+short_description = "An example application."
+long_description = """
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+eiusmod tempor incididunt ut labore et dolore magna aliqua.  Ut
+enim ad minim veniam, quis nostrud exercitation ullamco laboris
+nisi ut aliquip ex ea commodo consequat.
+"""
 ```
 
 ## Contributing

--- a/src/bundle/deb_bundle.rs
+++ b/src/bundle/deb_bundle.rs
@@ -122,13 +122,23 @@ fn generate_control_file(settings: &Settings, arch: &str, control_dir: &Path, da
     if !settings.cargo_settings.homepage.is_empty() {
         writeln!(&mut file, "Homepage: {}", settings.cargo_settings.homepage)?;
     }
-    // TODO(mdsteele): Split description into short and long sections.
-    let mut description = settings.cargo_settings.description.trim();
-    if description.is_empty() {
-        description = "(none)";
+    let mut short_description = settings.short_description().trim();
+    if short_description.is_empty() {
+        short_description = "(none)";
     }
-    writeln!(&mut file, "Description: {}", description)?;
-    writeln!(&mut file, " {}", description)?;
+    let mut long_description = settings.long_description().unwrap_or("").trim();
+    if long_description.is_empty() {
+        long_description = "(none)";
+    }
+    writeln!(&mut file, "Description: {}", short_description)?;
+    for line in long_description.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            writeln!(&mut file, " .")?;
+        } else {
+            writeln!(&mut file, " {}", line)?;
+        }
+    }
     file.flush()
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,7 +163,9 @@ pub struct Settings {
     pub resource_files: Vec<PathBuf>,
     pub bundle_script: Option<PathBuf>,
     pub icon_files: Vec<PathBuf>,
-    pub copyright: Option<String>
+    pub copyright: Option<String>,
+    pub short_desc: Option<String>,
+    pub long_desc: Option<String>,
 }
 
 impl Settings {
@@ -181,7 +183,9 @@ impl Settings {
             resource_files: vec![],
             bundle_script: None,
             icon_files: vec![],
-            copyright: None
+            copyright: None,
+            short_desc: None,
+            long_desc: None,
         };
 
         let table = try!({
@@ -228,6 +232,18 @@ impl Settings {
                     settings.copyright = Some(simple_parse!(String,
                                                             value,
                                                             "Invalid format for copyright notice in \
+                                                             Bundle.toml: Expected string, found {:?}"))
+                }
+                "short_description" => {
+                    settings.short_desc = Some(simple_parse!(String,
+                                                             value,
+                                                             "Invalid format for short description in \
+                                                              Bundle.toml: Expected string, found {:?}"))
+                }
+                "long_description" => {
+                    settings.long_desc = Some(simple_parse!(String,
+                                                            value,
+                                                            "Invalid format for long description in \
                                                              Bundle.toml: Expected string, found {:?}"))
                 }
                 "icon" => {
@@ -283,6 +299,14 @@ impl Settings {
 
     pub fn version_string(&self) -> &str {
         self.version_str.as_ref().unwrap_or(&self.cargo_settings.version)
+    }
+
+    pub fn short_description(&self) -> &str {
+        self.short_desc.as_ref().unwrap_or(&self.cargo_settings.description)
+    }
+
+    pub fn long_description(&self) -> Option<&str> {
+        self.long_desc.as_ref().map(String::as_str)
     }
 }
 


### PR DESCRIPTION
These fields are needed for both deb bundles and rpm bundles, each of which requires both a one-line description and a longer, multi-line description.