### PR TITLE
Implement iOS bundles

### DIFF
--- a/src/bundle/common.rs
+++ b/src/bundle/common.rs
@@ -1,5 +1,8 @@
 use std::ffi::OsStr;
+use std::fs::{self, File};
+use std::io::BufWriter;
 use std::path::Path;
+use walkdir::WalkDir;
 
 /// Returns true if the path has a filename indicating that it is a high-desity
 /// "retina" icon.  Specifically, returns true the the file stem ends with
@@ -11,4 +14,36 @@ pub fn is_retina<P: AsRef<Path>>(path: P) -> bool {
         .and_then(OsStr::to_str)
         .map(|stem| stem.ends_with("@2x"))
         .unwrap_or(false)
+}
+
+/// Creates a new file at the given path, creating any parent directories as
+/// needed.
+pub fn create_file(path: &Path) -> ::Result<BufWriter<File>> {
+    let parent = match path.parent() {
+        Some(dir) => dir,
+        None => bail!("Path has no parent: {:?}", path),
+    };
+    fs::create_dir_all(parent)?;
+    let file = File::create(path)?;
+    Ok(BufWriter::new(file))
+}
+
+/// Copies the file or directory (recursively) at `from` into the directory at
+/// `to`.  The `to` directory (and its parents) will be created if necessary.
+pub fn copy_to_dir(from: &Path, to_dir: &Path) -> ::Result<()> {
+    let parent = match from.parent() {
+        Some(dir) => dir,
+        None => bail!("Path has no parent: {:?}", from),
+    };
+    for entry in WalkDir::new(from) {
+        let entry = entry?;
+        if entry.file_type().is_file() {
+            let rel_path = entry.path().strip_prefix(parent).unwrap();
+            let dest_path = to_dir.join(rel_path);
+            let dest_dir = dest_path.parent().unwrap();
+            fs::create_dir_all(dest_dir)?;
+            fs::copy(entry.path(), &dest_path)?;
+        }
+    }
+    Ok(())
 }

--- a/src/bundle/ios_bundle.rs
+++ b/src/bundle/ios_bundle.rs
@@ -1,0 +1,121 @@
+// An iOS package is laid out like:
+//
+// Foobar.app         # Actually a directory
+//     Foobar             # The main binary executable of the app
+//     Info.plist         # An XML file containing the app's metadata
+//     ...                # Icons and other resource files
+//
+// See https://developer.apple.com/go/?id=bundle-structure for a full
+// explanation.
+
+use super::common;
+use Settings;
+use icns;
+use image::{self, GenericImage, ImageDecoder};
+use image::png::{PNGDecoder, PNGEncoder};
+use std::collections::BTreeSet;
+use std::ffi::OsStr;
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+pub fn bundle_project(settings: &Settings) -> ::Result<Vec<PathBuf>> {
+    let bundle_name = format!("{}.app", settings.bundle_name);
+    let bundle_dir = settings.cargo_settings.project_out_directory.join(&bundle_name);
+    fs::create_dir_all(&bundle_dir)?;
+    for res_path in &settings.resource_files {
+        common::copy_to_dir(res_path, &bundle_dir.join("Resources"))?;
+    }
+    let icon_filenames = generate_icon_files(&bundle_dir, settings)?;
+    generate_info_plist(&bundle_dir, settings, &icon_filenames)?;
+    let bin_path = bundle_dir.join(&settings.bundle_name);
+    fs::copy(&settings.cargo_settings.binary_file, bin_path)?;
+    Ok(vec![bundle_dir])
+}
+
+/// Generate the icon files and store them under the `bundle_dir`.
+fn generate_icon_files(bundle_dir: &Path, settings: &Settings) -> ::Result<Vec<String>> {
+    let mut filenames = Vec::new();
+    {
+        let mut get_dest_path = |width: u32, height: u32, is_retina: bool| {
+            let filename = format!("icon_{}x{}{}.png",
+                                   width,
+                                   height,
+                                   if is_retina { "@2x" } else { "" });
+            let path = bundle_dir.join(&filename);
+            filenames.push(filename);
+            path
+        };
+        let mut sizes = BTreeSet::new();
+        // Prefer PNG files.
+        for icon_path in settings.icon_files.iter().filter(|path| path.extension() == Some(OsStr::new("png"))) {
+            let mut decoder = PNGDecoder::new(File::open(icon_path)?);
+            let (width, height) = decoder.dimensions()?;
+            let is_retina = common::is_retina(icon_path);
+            if !sizes.contains(&(width, height, is_retina)) {
+                sizes.insert((width, height, is_retina));
+                let dest_path = get_dest_path(width, height, is_retina);
+                fs::copy(icon_path, dest_path)?;
+            }
+        }
+        // Fall back to non-PNG files for any missing sizes.
+        for icon_path in settings.icon_files.iter().filter(|path| path.extension() != Some(OsStr::new("png"))) {
+            if icon_path.extension() == Some(OsStr::new("icns")) {
+                let icon_family = icns::IconFamily::read(File::open(icon_path)?)?;
+                for icon_type in icon_family.available_icons() {
+                    let width = icon_type.screen_width();
+                    let height = icon_type.screen_height();
+                    let is_retina = icon_type.pixel_density() > 1;
+                    if !sizes.contains(&(width, height, is_retina)) {
+                        sizes.insert((width, height, is_retina));
+                        let dest_path = get_dest_path(width, height, is_retina);
+                        let icon = icon_family.get_icon_with_type(icon_type)?;
+                        icon.write_png(File::create(dest_path)?)?;
+                    }
+                }
+            } else {
+                let icon = try!(image::open(icon_path));
+                let (width, height) = icon.dimensions();
+                let is_retina = common::is_retina(icon_path);
+                if !sizes.contains(&(width, height, is_retina)) {
+                    sizes.insert((width, height, is_retina));
+                    let dest_path = get_dest_path(width, height, is_retina);
+                    let encoder = PNGEncoder::new(common::create_file(&dest_path)?);
+                    encoder.encode(&icon.raw_pixels(), width, height, icon.color())?;
+                }
+            }
+        }
+    }
+    Ok(filenames)
+}
+
+fn generate_info_plist(bundle_dir: &Path, settings: &Settings, icon_filenames: &Vec<String>) -> ::Result<()> {
+    let file = &mut common::create_file(&bundle_dir.join("Info.plist"))?;
+    write!(file,
+           "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+            <!DOCTYPE plist PUBLIC \"-//Apple Computer//DTD PLIST 1.0//EN\" \
+            \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n\
+            <plist version=\"1.0\">\n\
+            <dict>\n")?;
+    write!(file,
+           "  <key>CFBundleDisplayName</key>\n  <string>{}</string>\n",
+           settings.bundle_name)?;
+    write!(file,
+           "  <key>CFBundleIdentifier</key>\n  <string>{}</string>\n",
+           settings.identifier)?;
+    write!(file,
+           "  <key>CFBundleVersion</key>\n  <string>{}</string>\n",
+           settings.version_string())?;
+    if !icon_filenames.is_empty() {
+        write!(file, "  <key>CFBundleVersion</key>\n  <array>\n")?;
+        for filename in icon_filenames {
+            write!(file, "    <string>{}</string>\n", filename)?;
+        }
+        write!(file, "  </array>\n")?;
+    }
+    // Note that this key is true for all iOS apps, even non-iPhone ones.
+    write!(file, "  <key>LSRequiresIPhoneOS</key>\n  <true/>\n")?;
+    write!(file, "</dict>\n</plist>\n")?;
+    file.flush()?;
+    Ok(())
+}

--- a/src/bundle/mod.rs
+++ b/src/bundle/mod.rs
@@ -2,8 +2,9 @@ use {PackageType, Settings};
 use std::path::PathBuf;
 
 mod common;
-mod osx_bundle;
 mod deb_bundle;
+mod ios_bundle;
+mod osx_bundle;
 mod rpm_bundle;
 
 pub fn bundle_project(settings: Settings) -> ::Result<Vec<PathBuf>> {
@@ -11,6 +12,7 @@ pub fn bundle_project(settings: Settings) -> ::Result<Vec<PathBuf>> {
     for package_type in settings.package_types()? {
         paths.append(&mut match package_type {
             PackageType::OsxBundle => osx_bundle::bundle_project(&settings)?,
+            PackageType::IosBundle => ios_bundle::bundle_project(&settings)?,
             PackageType::Deb => deb_bundle::bundle_project(&settings)?,
             PackageType::Rpm => rpm_bundle::bundle_project(&settings)?,
         });

--- a/src/bundle/osx_bundle.rs
+++ b/src/bundle/osx_bundle.rs
@@ -11,9 +11,8 @@
 //         Frameworks     # A directory containing private frameworks (shared libraries)
 //         ...            # Any other optional files the developer wants to place here
 //
-// See https://developer.apple.com/library/content/documentation/CoreFoundation/Conceptual/
-// CFBundles/Introduction/Introduction.html#//apple_ref/doc/uid/10000123i-CH1-SW1 for a
-// full explanation.
+// See https://developer.apple.com/go/?id=bundle-structure for a full
+// explanation.
 //
 // Currently, cargo-bundle does not support Frameworks, nor does it support placing arbitrary
 // files into the `Contents` directory of the bundle.

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,9 +175,10 @@ pub struct Settings {
 impl Settings {
     pub fn new(current_dir: PathBuf, matches: &ArgMatches) -> ::Result<Self> {
         let package_type = match matches.value_of("format") {
-            // Other types we may eventually want to support: ios, apk, win
+            // Other types we may eventually want to support: apk, win
             None => None,
             Some("deb") => Some(PackageType::Deb),
+            Some("ios") => Some(PackageType::IosBundle),
             Some("osx") => Some(PackageType::OsxBundle),
             Some("rpm") => Some(PackageType::Rpm),
             Some(format) => bail!("Unsupported bundle format: {}", format),
@@ -342,6 +343,7 @@ impl Settings {
             };
             match target_os {
                 "macos" => Ok(vec![PackageType::OsxBundle]),
+                "ios" => Ok(vec![PackageType::IosBundle]),
                 "linux" => Ok(vec![PackageType::Deb]), // TODO: Do Rpm too, once it's implemented.
                 os => bail!("Native {} bundles not yet supported.", os),
             }
@@ -364,6 +366,7 @@ impl Settings {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum PackageType {
     OsxBundle,
+    IosBundle,
     Deb,
     Rpm
 }


### PR DESCRIPTION
Implements initial support for iOS app bundles, which are a slight variation on OS X app bundles (see https://developer.apple.com/go/?id=bundle-structure).  This should allow using the `--target` flag to cross-compile a Rust app to iOS, and then bundle it into an iOS app that can e.g. be run on an iOS simulator for testing.