### PR TITLE
Add support for [package.metadata.bundle] section in Cargo.toml

### DIFF
--- a/src/bundle/common.rs
+++ b/src/bundle/common.rs
@@ -64,3 +64,18 @@ pub fn print_bundling(filename: &str) -> ::Result<()> {
     output.flush()?;
     Ok(())
 }
+
+/// Prints a warning message to stdout, in the same format that `cargo` uses.
+pub fn print_warning(message: &str) -> ::Result<()> {
+    let mut output = match term::stdout() {
+        Some(terminal) => terminal,
+        None => bail!("Can't write to stdout"),
+    };
+    output.attr(term::Attr::Bold)?;
+    output.fg(term::color::YELLOW)?;
+    write!(output, "warning:")?;
+    output.reset()?;
+    write!(output, " {}\n", message)?;
+    output.flush()?;
+    Ok(())
+}


### PR DESCRIPTION
This change implements the suggestion in issue #5.  For now, the `Bundle.toml` file is still supported and will be used if found, but `cargo-bundle` will print a warning in that case, indicating that `[package.metadata.bundle]` should be used instead, and that support for `Bundle.toml` will eventually be removed.