### PR TITLE
Improve error reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,23 +1,3 @@
-[root]
-name = "cargo-bundle"
-version = "0.2.0"
-dependencies = [
- "ar 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.19.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "icns 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "image 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libflate 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "md5 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "tar 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "target_build_utils 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "term 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "adler32"
 version = "0.3.0"
@@ -70,6 +50,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "byteorder"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cargo-bundle"
+version = "0.2.0"
+dependencies = [
+ "ar 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.19.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "icns 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "image 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libflate 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "md5 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tar 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "target_build_utils 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "cfg-if"
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "error-chain"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -583,7 +583,7 @@ dependencies = [
 "checksum deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1614659040e711785ed8ea24219140654da1729f3ec8a47a9719d041112fe7bf"
 "checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
 "checksum enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "be4551092f4d519593039259a9ed8daedf0da12e5109c5280338073eaeb81180"
-"checksum error-chain 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e92ecf0a508c8e074c0e6fa8fe0fa38414848ad4dfc4db6f74c5e9753330b248"
+"checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "5363ab8e4139b8568a6237db5248646e5a8a2f89bd5ccb02092182b11fd3e922"
 "checksum flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "3eeb481e957304178d2e782f2da1257f1434dfecbae883bafb61ada2a9fea3bb"
 "checksum gcc 0.3.41 (registry+https://github.com/rust-lang/crates.io-index)" = "3689e1982a563af74960ae3a4758aa632bb8fd984cfc3cc3b60ee6109477ab6e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "Wrap rust executables in OS-specific app bundles"
 [dependencies]
 ar = "0.2"
 clap = "^2"
-error-chain = "^0.9"
+error-chain = "0.11"
 icns = "^0.2"
 image = "0.12"
 libflate = "0.1"

--- a/src/bundle/mod.rs
+++ b/src/bundle/mod.rs
@@ -1,12 +1,13 @@
-pub use self::settings::{PackageType, Settings};
-use std::path::PathBuf;
-
 mod common;
 mod deb_bundle;
 mod ios_bundle;
 mod osx_bundle;
 mod rpm_bundle;
 mod settings;
+
+pub use self::common::{print_error, print_finished};
+pub use self::settings::{PackageType, Settings};
+use std::path::PathBuf;
 
 pub fn bundle_project(settings: Settings) -> ::Result<Vec<PathBuf>> {
     let mut paths = Vec::new();

--- a/src/bundle/settings.rs
+++ b/src/bundle/settings.rs
@@ -103,7 +103,7 @@ impl Settings {
             } else if let Some(bundle_settings) = cargo_settings.package.metadata.as_ref().and_then(|metadata| metadata.bundle.as_ref()) {
                 bundle_settings.clone()
             } else {
-                bail!("No [package.metadata.bundle] section or ]Bundle.toml file found.");
+                bail!("No [package.metadata.bundle] section or Bundle.toml file found.");
             }
         };
         Ok(Settings {

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,12 +52,10 @@ fn build_project_if_unbuilt(settings: &Settings) -> Result<()> {
     Ok(())
 }
 
-quick_main!(run);
-
 fn run() -> ::Result<()> {
     let m = App::new("cargo-bundle")
                 .author("George Burton <burtonageo@gmail.com>")
-                .about("Bundle rust executables into OS bundles")
+                .about("Bundle Rust executables into OS bundles")
                 .version(format!("v{}", crate_version!()).as_str())
                 .bin_name("cargo")
                 .settings(&[AppSettings::GlobalVersion, AppSettings::SubcommandRequired])
@@ -76,15 +74,13 @@ fn run() -> ::Result<()> {
                           Ok(s)
                       })
             .and_then(bundle_project)?;
-        let pluralised = if output_paths.len() == 1 {
-            "bundle"
-        } else {
-            "bundles"
-        };
-        println!("{} {} created at:", output_paths.len(), pluralised);
-        for bundle in output_paths {
-            println!("\t{}", bundle.display());
-        }
+        bundle::print_finished(&output_paths)?;
     }
     Ok(())
+}
+
+fn main() {
+    if let Err(error) = run() {
+        bundle::print_error(&error).unwrap();
+    }
 }


### PR DESCRIPTION
Use the `chain_err()` method from `error_chain` to give more context for lower-level errors, and tweak the formatting to better resemble errors from other cargo subcommands.