### PR TITLE
Workspace awareness

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ error_chain! {
 }
 
 /// Runs `cargo build` to make sure the binary file is up-to-date.
-fn build_project_if_unbuilt(settings: &Settings) -> Result<()> {
+fn build_project_if_unbuilt(settings: &Settings) -> ::Result<()> {
     let mut args = vec!["build".to_string()];
     if let Some(triple) = settings.target_triple() {
         args.push(format!("--target={}", triple));


### PR DESCRIPTION
Here is a WIP Pull-request that implements simple workspace awareness.

Care to take a look at give me some review comments / feedback?

I have left in some comments that go beyond the scope of the actual code changes as FYI.
I would take parts of them and make them separate enhancement issues for cargo-bundle if you agree, and remove the comments - so the comments match the code.

Note that I extracted CargoSettings from Settings (and used just Package) as:
- only the Package part of CargoSettings was actually used
- the CargoSettings implementation is now more alligned with all possible Cargo.toml files (where package is optional), so it can also be used for reading parent Cargo.toml files in a workspace 