### PR TITLE
Add OS-specific setting for Debian dependencies (fixes #25)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -29,7 +29,11 @@ cross-compile and bundle an application for another OS, add an appropriate
 
 ## Bundle manifest format
 
- There are several fields in the `[package.metadata.bundle]` section.
+There are several fields in the `[package.metadata.bundle]` section.
+
+### General settings
+
+These settings apply to bundles for all (or most) OSes.
 
  * `name`: The name of the built application. If this is not present, then it will use the `name` value from
            your `Cargo.toml` file.
@@ -54,6 +58,14 @@ cross-compile and bundle an application for another OS, add an appropriate
                         will use the `description` value from your `Cargo.toml` file.
  * `long_description`: [OPTIONAL] A longer, multi-line description of the application.
 
+### Debian-specific settings
+
+These settings are used only when bundling `deb` packages.
+
+* `deb_depends`: A list of strings indicating other packages (e.g. shared
+  libraries) that this package depends on to be installed.  If present, this
+  forms the `Depends:` field of the `deb` package control file.
+
 ### Example `Cargo.toml`:
 
 ```toml
@@ -75,6 +87,7 @@ eiusmod tempor incididunt ut labore et dolore magna aliqua.  Ut
 enim ad minim veniam, quis nostrud exercitation ullamco laboris
 nisi ut aliquip ex ea commodo consequat.
 """
+deb_depends = ["libgl1-mesa-glx", "libsdl2-2.0-0 (>= 2.0.5)"]
 ```
 
 ## Contributing

--- a/src/bundle/deb_bundle.rs
+++ b/src/bundle/deb_bundle.rs
@@ -138,6 +138,10 @@ fn generate_control_file(settings: &Settings, arch: &str, control_dir: &Path, da
     if !settings.homepage_url().is_empty() {
         writeln!(&mut file, "Homepage: {}", settings.homepage_url())?;
     }
+    let dependencies = settings.debian_dependencies();
+    if !dependencies.is_empty() {
+        writeln!(&mut file, "Depends: {}", dependencies.join(", "))?;
+    }
     let mut short_description = settings.short_description().trim();
     if short_description.is_empty() {
         short_description = "(none)";

--- a/src/bundle/settings.rs
+++ b/src/bundle/settings.rs
@@ -61,6 +61,7 @@ pub enum BuildArtifact {
 
 #[derive(Clone, Debug, Deserialize)]
 struct BundleSettings {
+    // General settings:
     name: Option<String>,
     identifier: Option<String>,
     icon: Option<Vec<String>>,
@@ -70,6 +71,9 @@ struct BundleSettings {
     short_description: Option<String>,
     long_description: Option<String>,
     script: Option<PathBuf>,
+    // OS-specific settings:
+    deb_depends: Option<Vec<String>>,
+    // Bundles for other binaries/examples:
     bin: Option<HashMap<String, BundleSettings>>,
     example: Option<HashMap<String, BundleSettings>>,
 }
@@ -357,6 +361,13 @@ impl Settings {
 
     pub fn long_description(&self) -> Option<&str> {
         self.bundle_settings.long_description.as_ref().map(String::as_str)
+    }
+
+    pub fn debian_dependencies(&self) -> &[String] {
+        match self.bundle_settings.deb_depends {
+            Some(ref dependencies) => dependencies.as_slice(),
+            None => &[],
+        }
     }
 }
 


### PR DESCRIPTION
I expect more OS-specific settings to follow this one (see issue #33).  Hopefully most users won't need them (since, to me, part of the benefit of `cargo-bundle` is avoiding the need to worry about OS-specific details), but it's good to have these knobs when necessary.