### PR TITLE
Add OS-specific setting for OSX frameworks (for #33)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,7 @@ dependencies = [
  "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "target_build_utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -158,6 +159,14 @@ dependencies = [
  "textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -714,6 +723,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rayon"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,6 +771,14 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -874,6 +908,18 @@ dependencies = [
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1117,6 +1163,7 @@ dependencies = [
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
 "checksum clap 2.30.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1c07b9257a00f3fc93b7f3c417fc15607ec7a56823bc2c37ec744e266387de5b"
+"checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cocoa 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b0c23085dde1ef4429df6e5896b89356d35cdd321fb43afe3e378d010bb5adc6"
 "checksum color_quant 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a475fc4af42d83d28adf72968d9bcfaf035a1a9381642d8e85d8a04957767b0d"
 "checksum core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "286e0b41c3a20da26536c6000a280585d519fd07b3956b43aed8a79e9edce980"
@@ -1186,10 +1233,13 @@ dependencies = [
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
+"checksum rand 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "12397506224b2f93e6664ffc4f664b29be8208e5157d3d90b44f09b5fae470ea"
+"checksum rand_core 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "edecf0f94da5551fc9b492093e30b041a891657db7940ee221f9d2f66e82eef2"
 "checksum rayon 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "485541959c8ecc49865526fe6c4de9653dd6e60d829d6edf0be228167b60372d"
 "checksum rayon-core 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d24ad214285a7729b174ed6d3bcfcb80177807f959d95fafd5bfc5c4f201ac8"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
+"checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum rustc-demangle 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f312457f8a4fa31d3581a6f423a70d6c33a10b95291985df55f1ff670ec10ce8"
 "checksum same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfb6eded0b06a0b512c8ddbcf04089138c9b4362c2f696f3c3d76039d68f3637"
 "checksum scoped_threadpool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "4ea459fe3ceff01e09534847c49860891d3ff1c12b4eb7731b67f2778fb60190"
@@ -1207,6 +1257,7 @@ dependencies = [
 "checksum tar 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)" = "1605d3388ceb50252952ffebab4b5dc43017ead7e4481b175961c283bb951195"
 "checksum target_build_utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "013d134ae4a25ee744ad6129db589018558f620ddfa44043887cdd45fa08e75c"
 "checksum tempfile 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "11ce2fe9db64b842314052e2421ac61a73ce41b898dc8e3750398b219c5fc1e0"
+"checksum tempfile 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c4b103c6d08d323b92ff42c8ce62abcd83ca8efa7fd5bf7927efefec75f58c76"
 "checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ uuid = { version = "0.5", features = ["v5"] }
 walkdir = "2"
 
 [dev-dependencies]
+tempfile = "3"
 winit = "0.11"
 
 [[example]]

--- a/Readme.md
+++ b/Readme.md
@@ -72,6 +72,25 @@ These settings are used only when bundling `deb` packages.
   libraries) that this package depends on to be installed.  If present, this
   forms the `Depends:` field of the `deb` package control file.
 
+### Mac OS X-specific settings
+
+These settings are used only when bundling `osx` packages.
+
+* `osx_frameworks`: A list of strings indicating any Mac OS X frameworks that
+  need to be bundled with the app.  Each string can either be the name of a
+  framework (without the `.framework` extension, e.g. `"SDL2"`), in which case
+  `cargo-bundle` will search for that framework in the standard install
+  locations (`~/Library/Frameworks/`, `/Library/Frameworks/`, and
+  `/Network/Library/Frameworks/`), or a path to a specific framework bundle
+  (e.g. `./data/frameworks/SDL2.framework`).  Note that this setting just makes
+  `cargo-bundle` copy the specified frameworks into the OS X app bundle (under
+  `Foobar.app/Contents/Frameworks/`); you are still responsible for (1)
+  arranging for the compiled binary to link against those frameworks (e.g. by
+  emitting lines like `cargo:rustc-link-lib=framework=SDL2` from your
+  `build.rs` script), and (2) embedding the correct rpath in your binary
+  (e.g. by running `install_name_tool -add_rpath
+  "@executable_path/../Frameworks" path/to/binary` after compiling).
+
 ### Example `Cargo.toml`:
 
 ```toml
@@ -95,6 +114,7 @@ enim ad minim veniam, quis nostrud exercitation ullamco laboris
 nisi ut aliquip ex ea commodo consequat.
 """
 deb_depends = ["libgl1-mesa-glx", "libsdl2-2.0-0 (>= 2.0.5)"]
+osx_frameworks = ["SDL2"]
 ```
 
 ## Contributing

--- a/src/bundle/common.rs
+++ b/src/bundle/common.rs
@@ -1,9 +1,11 @@
 use ::ResultExt;
+use std;
 use std::ffi::OsStr;
 use std::fs::{self, File};
 use std::io::{self, BufWriter, Write};
 use std::path::{Component, Path, PathBuf};
 use term;
+use walkdir;
 
 /// Returns true if the path has a filename indicating that it is a high-desity
 /// "retina" icon.  Specifically, returns true the the file stem ends with
@@ -31,6 +33,26 @@ pub fn create_file(path: &Path) -> ::Result<BufWriter<File>> {
     Ok(BufWriter::new(file))
 }
 
+#[cfg(unix)]
+fn symlink_dir(src: &Path, dst: &Path) -> io::Result<()> {
+    std::os::unix::fs::symlink(src, dst)
+}
+
+#[cfg(windows)]
+fn symlink_dir(src: &Path, dst: &Path) -> io::Result<()> {
+    std::os::windows::fs::symlink_dir(src, dst)
+}
+
+#[cfg(unix)]
+fn symlink_file(src: &Path, dst: &Path) -> io::Result<()> {
+    std::os::unix::fs::symlink(src, dst)
+}
+
+#[cfg(windows)]
+fn symlink_file(src: &Path, dst: &Path) -> io::Result<()> {
+    std::os::windows::fs::symlink_file(src, dst)
+}
+
 /// Copies a regular file from one path to another, creating any parent
 /// directories of the destination path as necessary.  Fails if the source path
 /// is a directory or doesn't exist.
@@ -48,6 +70,45 @@ pub fn copy_file(from: &Path, to: &Path) -> ::Result<()> {
     fs::copy(from, to).chain_err(|| {
         format!("Failed to copy {:?} to {:?}", from, to)
     })?;
+    Ok(())
+}
+
+/// Recursively copies a directory file from one path to another, creating any
+/// parent directories of the destination path as necessary.  Fails if the
+/// source path is not a directory or doesn't exist, or if the destination path
+/// already exists.
+pub fn copy_dir(from: &Path, to: &Path) -> ::Result<()> {
+    if !from.exists() {
+        bail!("{:?} does not exist", from);
+    }
+    if !from.is_dir() {
+        bail!("{:?} is not a directory", from);
+    }
+    if to.exists() {
+        bail!("{:?} already exists", to);
+    }
+    let parent = to.parent().unwrap();
+    fs::create_dir_all(parent).chain_err(|| {
+        format!("Failed to create {:?}", parent)
+    })?;
+    for entry in walkdir::WalkDir::new(from) {
+        let entry = entry?;
+        debug_assert!(entry.path().starts_with(from));
+        let rel_path = entry.path().strip_prefix(from).unwrap();
+        let dest_path = to.join(rel_path);
+        if entry.file_type().is_symlink() {
+            let target = fs::read_link(entry.path())?;
+            if entry.path().is_dir() {
+                symlink_dir(&target, &dest_path)?;
+            } else {
+                symlink_file(&target, &dest_path)?;
+            }
+        } else if entry.file_type().is_dir() {
+            fs::create_dir(dest_path)?;
+        } else {
+            fs::copy(entry.path(), dest_path)?;
+        }
+    }
     Ok(())
 }
 
@@ -157,5 +218,73 @@ pub fn print_error(error: &::Error) -> ::Result<()> {
         }
         output.flush()?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std;
+    use std::io::Write;
+    use std::path::PathBuf;
+    use super::{copy_dir, create_file, symlink_file, is_retina, resource_relpath};
+    use tempfile;
+
+    #[test]
+    fn create_file_with_parent_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(!tmp.path().join("parent").exists());
+        {
+            let mut file = create_file(&tmp.path().join("parent/file.txt")).unwrap();
+            write!(file, "Hello, world!\n").unwrap();
+        }
+        assert!(tmp.path().join("parent").is_dir());
+        assert!(tmp.path().join("parent/file.txt").is_file());
+    }
+
+    #[test]
+    fn copy_dir_with_symlinks() {
+        // Create a directory structure that looks like this:
+        //   ${TMP}/orig/
+        //       sub/
+        //           file.txt
+        //       link -> sub/file.txt
+        let tmp = tempfile::tempdir().unwrap();
+        {
+            let mut file = create_file(&tmp.path().join("orig/sub/file.txt")).unwrap();
+            write!(file, "Hello, world!\n").unwrap();
+        }
+        symlink_file(&PathBuf::from("sub/file.txt"),
+                     &tmp.path().join("orig/link")).unwrap();
+        assert_eq!(std::fs::read(tmp.path().join("orig/link")).unwrap().as_slice(),
+                   b"Hello, world!\n");
+        // Copy ${TMP}/orig to ${TMP}/parent/copy, and make sure that the
+        // directory structure, file, and symlink got copied correctly.
+        copy_dir(&tmp.path().join("orig"), &tmp.path().join("parent/copy")).unwrap();
+        assert!(tmp.path().join("parent/copy").is_dir());
+        assert!(tmp.path().join("parent/copy/sub").is_dir());
+        assert!(tmp.path().join("parent/copy/sub/file.txt").is_file());
+        assert_eq!(std::fs::read(tmp.path().join("parent/copy/sub/file.txt")).unwrap().as_slice(),
+                   b"Hello, world!\n");
+        assert!(tmp.path().join("parent/copy/link").exists());
+        assert_eq!(std::fs::read_link(tmp.path().join("parent/copy/link")).unwrap(),
+                   PathBuf::from("sub/file.txt"));
+        assert_eq!(std::fs::read(tmp.path().join("parent/copy/link")).unwrap().as_slice(),
+                   b"Hello, world!\n");
+    }
+
+    #[test]
+    fn retina_icon_paths() {
+        assert!(!is_retina("data/icons/512x512.png"));
+        assert!(is_retina("data/icons/512x512@2x.png"));
+    }
+
+    #[test]
+    fn resource_relative_paths() {
+        assert_eq!(resource_relpath(&PathBuf::from("./data/images/button.png")),
+                   PathBuf::from("data/images/button.png"));
+        assert_eq!(resource_relpath(&PathBuf::from("../../images/wheel.png")),
+                   PathBuf::from("_up_/_up_/images/wheel.png"));
+        assert_eq!(resource_relpath(&PathBuf::from("/home/ferris/crab.png")),
+                   PathBuf::from("_root_/home/ferris/crab.png"));
     }
 }

--- a/src/bundle/settings.rs
+++ b/src/bundle/settings.rs
@@ -75,6 +75,7 @@ struct BundleSettings {
     script: Option<PathBuf>,
     // OS-specific settings:
     deb_depends: Option<Vec<String>>,
+    osx_frameworks: Option<Vec<String>>,
     // Bundles for other binaries/examples:
     bin: Option<HashMap<String, BundleSettings>>,
     example: Option<HashMap<String, BundleSettings>>,
@@ -372,6 +373,13 @@ impl Settings {
     pub fn debian_dependencies(&self) -> &[String] {
         match self.bundle_settings.deb_depends {
             Some(ref dependencies) => dependencies.as_slice(),
+            None => &[],
+        }
+    }
+
+    pub fn osx_frameworks(&self) -> &[String] {
+        match self.bundle_settings.osx_frameworks {
+            Some(ref frameworks) => frameworks.as_slice(),
             None => &[],
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,9 @@ extern crate toml;
 extern crate uuid;
 extern crate walkdir;
 
+#[cfg(test)]
+extern crate tempfile;
+
 mod bundle;
 
 use bundle::{BuildArtifact, PackageType, Settings, bundle_project};


### PR DESCRIPTION
This provides an easy way to bundle frameworks that your binary depends on into your OS X app bundle.