### PR TITLE
Use different values for CFBundleVersion and CFBundleShortVersionString

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,7 @@ version = "0.3.0"
 dependencies = [
  "ar 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cab 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ cargo-bundle's support for bundling crate examples.
 [dependencies]
 ar = "0.3"
 cab = "0.1"
+chrono = "0.4"
 clap = "^2"
 error-chain = "0.12"
 glob = "0.2"

--- a/src/bundle/osx_bundle.rs
+++ b/src/bundle/osx_bundle.rs
@@ -19,6 +19,7 @@
 
 use super::common;
 use {ResultExt, Settings};
+use chrono;
 use icns;
 use image::{self, GenericImage};
 use std::cmp::min;
@@ -82,6 +83,7 @@ fn copy_binary_to_bundle(bundle_directory: &Path, settings: &Settings) -> ::Resu
 
 fn create_info_plist(bundle_dir: &Path, bundle_icon_file: Option<PathBuf>,
                      settings: &Settings) -> ::Result<()> {
+    let build_number = chrono::Utc::now().format("%Y%m%d.%H%M%S");
     let file = &mut common::create_file(&bundle_dir.join("Info.plist"))?;
     write!(file,
            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
@@ -119,7 +121,7 @@ fn create_info_plist(bundle_dir: &Path, bundle_icon_file: Option<PathBuf>,
            settings.version_string())?;
     write!(file,
            "  <key>CFBundleVersion</key>\n  <string>{}</string>\n",
-           settings.version_string())?;
+           build_number)?;
     write!(file, "  <key>CSResourcesFileMapped</key>\n  <true/>\n")?;
     if let Some(category) = settings.app_category() {
         write!(file,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 extern crate ar;
 extern crate cab;
+extern crate chrono;
 #[macro_use]
 extern crate clap;
 #[macro_use]


### PR DESCRIPTION
`CFBundleShortVersionString` is the "human-readable" version number (e.g. "1.0.0"), whereas `CFBundleVersion` is supposed to be a monotonic build number that changes with every build (in particular, when submitting to the app store, each candidate build must have a different `CFBundleVersion` even if the human-readable version number stays the same).  To keep things simple, this PR just uses a UTC timestamp as the build number.