### PR TITLE
Use panic rather than bail to pass through the exit code

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ fn build_project_if_unbuilt(settings: &Settings) -> ::Result<()> {
     }
     let status = process::Command::new("cargo").args(args).status()?;
     if !status.success() {
-        panic!("Result of `cargo build` operation was unsuccessful: {}",
+        bail!("Result of `cargo build` operation was unsuccessful: {}",
               status);
     }
     Ok(())
@@ -125,5 +125,6 @@ fn run() -> ::Result<()> {
 fn main() {
     if let Err(error) = run() {
         bundle::print_error(&error).unwrap();
+        std::process::exit(1);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ fn build_project_if_unbuilt(settings: &Settings) -> ::Result<()> {
     }
     let status = process::Command::new("cargo").args(args).status()?;
     if !status.success() {
-        bail!("Result of `cargo build` operation was unsuccessful: {}",
+        panic!("Result of `cargo build` operation was unsuccessful: {}",
               status);
     }
     Ok(())


### PR DESCRIPTION
Closes #81.

I don't actually know if this is the right way to do it. The `bail` macro returns an error type and it should presumably propigate the error up to a non-zero exit status code to main but that doesn't seem to be the case. Thoughts?