### PR TITLE
Allow specifying the Exec field for the `.desktop`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -65,6 +65,15 @@ These settings apply to bundles for all (or most) OSes.
                         will use the `description` value from your `Cargo.toml` file.
  * `long_description`: [OPTIONAL] A longer, multi-line description of the application.
 
+### Linux-specific settings
+
+These settings are used only when bundling Linux compatible packages (currently `deb` only).
+
+* `linux_exec_args`: A single string which is inserted after the name of the binary in the `Exec`
+  field in the `.desktop` file. For example if the binary is called `my_program` and
+  `linux_exec_args = "%f"` then the Exec filed will be `Exec=my_program %f`. Find out more from the
+  [specification](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#exec-variables)
+
 ### Debian-specific settings
 
 These settings are used only when bundling `deb` packages.

--- a/src/bundle/deb_bundle.rs
+++ b/src/bundle/deb_bundle.rs
@@ -115,7 +115,12 @@ fn generate_desktop_file(settings: &Settings, data_dir: &Path) -> ::Result<()> {
     if !settings.short_description().is_empty() {
         write!(file, "Comment={}\n", settings.short_description())?;
     }
-    write!(file, "Exec={}\n", bin_name)?;
+    let exec;
+    match settings.linux_exec_args() {
+        Some(args) => exec = format!("{} {}", bin_name, args),
+        None => exec = bin_name.to_owned(),
+    }
+    write!(file, "Exec={}\n", exec)?;
     write!(file, "Icon={}\n", bin_name)?;
     write!(file, "Name={}\n", settings.bundle_name())?;
     write!(file, "Terminal=false\n")?;

--- a/src/bundle/settings.rs
+++ b/src/bundle/settings.rs
@@ -74,6 +74,7 @@ struct BundleSettings {
     long_description: Option<String>,
     script: Option<PathBuf>,
     // OS-specific settings:
+    linux_exec_args: Option<String>,
     deb_depends: Option<Vec<String>>,
     osx_frameworks: Option<Vec<String>>,
     osx_minimum_system_version: Option<String>,
@@ -399,6 +400,10 @@ impl Settings {
             Some(ref dependencies) => dependencies.as_slice(),
             None => &[],
         }
+    }
+
+    pub fn linux_exec_args(&self) -> Option<&str> {
+        self.bundle_settings.linux_exec_args.as_ref().map(String::as_str)
     }
 
     pub fn osx_frameworks(&self) -> &[String] {


### PR DESCRIPTION
Enables programs bundled with cargo-bundle to be considered when selecting a program to "open with..." under GNOME.