### PR TITLE
Allow specifying supported mime types for linux.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -65,6 +65,13 @@ These settings apply to bundles for all (or most) OSes.
                         will use the `description` value from your `Cargo.toml` file.
  * `long_description`: [OPTIONAL] A longer, multi-line description of the application.
 
+### Linux-specific settings
+
+These settings are used only when bundling Linux compatible packages (currently `deb` only).
+
+* `linux_mime_types`: A list of strings which represent mime types. If present, these are assigned
+  to the `MimeType` field of the .desktop file.
+
 ### Debian-specific settings
 
 These settings are used only when bundling `deb` packages.

--- a/src/bundle/deb_bundle.rs
+++ b/src/bundle/deb_bundle.rs
@@ -105,6 +105,10 @@ fn generate_desktop_file(settings: &Settings, data_dir: &Path) -> ::Result<()> {
     let desktop_file_name = format!("{}.desktop", bin_name);
     let desktop_file_path = data_dir.join("usr/share/applications").join(desktop_file_name);
     let file = &mut common::create_file(&desktop_file_path)?;
+    let mime_types = settings.linux_mime_types().iter().fold(
+        "".to_owned(),
+        |acc, s| format!("{}{};", acc, s)
+    );
     // For more information about the format of this file, see
     // https://developer.gnome.org/integration-guide/stable/desktop-files.html.en
     write!(file, "[Desktop Entry]\n")?;
@@ -120,6 +124,7 @@ fn generate_desktop_file(settings: &Settings, data_dir: &Path) -> ::Result<()> {
     write!(file, "Name={}\n", settings.bundle_name())?;
     write!(file, "Terminal=false\n")?;
     write!(file, "Type=Application\n")?;
+    write!(file, "MimeType={}\n", mime_types)?;
     write!(file, "Version={}\n", settings.version_string())?;
     Ok(())
 }

--- a/src/bundle/settings.rs
+++ b/src/bundle/settings.rs
@@ -74,6 +74,7 @@ struct BundleSettings {
     long_description: Option<String>,
     script: Option<PathBuf>,
     // OS-specific settings:
+    linux_mime_types: Option<Vec<String>>,
     deb_depends: Option<Vec<String>>,
     osx_frameworks: Option<Vec<String>>,
     osx_minimum_system_version: Option<String>,
@@ -397,6 +398,13 @@ impl Settings {
     pub fn debian_dependencies(&self) -> &[String] {
         match self.bundle_settings.deb_depends {
             Some(ref dependencies) => dependencies.as_slice(),
+            None => &[],
+        }
+    }
+
+    pub fn linux_mime_types(&self) -> &[String] {
+        match self.bundle_settings.linux_mime_types {
+            Some(ref mime_types) => mime_types.as_slice(),
             None => &[],
         }
     }


### PR DESCRIPTION
Fixes #86. 

Please consider merging #87 first.