### PR TITLE
Omit the `Version` field from the desktop file

### DIFF
--- a/src/bundle/deb_bundle.rs
+++ b/src/bundle/deb_bundle.rs
@@ -130,7 +130,8 @@ fn generate_desktop_file(settings: &Settings, data_dir: &Path) -> ::Result<()> {
     write!(file, "Terminal=false\n")?;
     write!(file, "Type=Application\n")?;
     write!(file, "MimeType={}\n", mime_types)?;
-    write!(file, "Version={}\n", settings.version_string())?;
+    // The `Version` field is omitted on pupose. See `generate_control_file` for specifying
+    // the application version.
     Ok(())
 }
 


### PR DESCRIPTION
The version field in the desktop file does *not* specify the application version. Instead it refers to the version of the Desktop Entry Specification and if the provided version is not recognized by the system the desktop file may be refused to be installed as seen at https://github.com/ArturKovacs/emulsion/issues/162

It seems best to omit this field.