### PR TITLE
Add support for --profile option

### DIFF
--- a/src/bundle/settings.rs
+++ b/src/bundle/settings.rs
@@ -158,9 +158,12 @@ impl Settings {
         let profile = if matches.is_present("release") {
             "release".to_string()
         } else if let Some(profile) = matches.value_of("profile") {
+            if profile == "debug" {
+                bail!("Profile name `debug` is reserved")
+            }
             profile.to_string()
         } else {
-            "debug".to_string()
+            "dev".to_string()
         };
         let all_features = matches.is_present("all-features");
         let no_default_features = matches.is_present("no-default-features");
@@ -234,7 +237,7 @@ impl Settings {
         if let &Some((ref triple, _)) = target {
             path.push(triple);
         }
-        path.push(profile);
+        path.push(if profile == "dev" { "debug" } else { profile });
         if let &BuildArtifact::Example(_) = build_artifact {
             path.push("examples");
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ fn build_project_if_unbuilt(settings: &Settings) -> ::Result<()> {
         }
     }
     match settings.build_profile() {
-        "debug" => {}
+        "dev" => {}
         "release" => {
             args.push("--release".to_string());
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,8 +65,15 @@ fn build_project_if_unbuilt(settings: &Settings) -> ::Result<()> {
             args.push(format!("--example={}", name));
         }
     }
-    if settings.is_release_build() {
-        args.push("--release".to_string());
+    match settings.build_profile() {
+        "debug" => {}
+        "release" => {
+            args.push("--release".to_string());
+        }
+        custom => {
+            args.push("--profile".to_string());
+            args.push(custom.to_string());
+        }
     }
     if settings.all_features() {
         args.push("--all-features".to_string());
@@ -112,6 +119,11 @@ fn run() -> ::Result<()> {
                     .arg(Arg::with_name("release")
                          .long("release")
                          .help("Build a bundle from a target built in release mode"))
+                    .arg(Arg::with_name("profile")
+                        .long("profile")
+                        .value_name("NAME")
+                        .conflicts_with("release")
+                        .help("Build a bundle from a target build using the given profile"))
                     .arg(Arg::with_name("target")
                          .long("target")
                          .value_name("TRIPLE")


### PR DESCRIPTION
# This PR
This PR adds support for cargo's `--profile` option taking a single argument, being the name of the custom profile to use. This allows users to build bundles with custom cargo profiles. Cargo received the `--profile` feature in Rust 1.57.0. The cargo documentation specifies that the build directory used for a custom profile is `target/<profile-name>` where `<profile-name>` is the name of the profile being built. This PR accounts for the custom profile build directories and builds bundles in the proper sub-directories.

# Linked Issues
This PR closes #106.