### PR TITLE
Add uilaunchstoryboardname key to ios plist files

### DIFF
--- a/src/bundle/ios_bundle.rs
+++ b/src/bundle/ios_bundle.rs
@@ -134,6 +134,7 @@ fn generate_info_plist(bundle_dir: &Path, settings: &Settings, icon_filenames: &
     write!(file, "  <key>CFBundleVersion</key>\n  <string>{}</string>\n", settings.version_string())?;
     write!(file, "  <key>CFBundleShortVersionString</key>\n  <string>{}</string>\n", settings.version_string())?;
     write!(file, "  <key>CFBundleDevelopmentRegion</key>\n  <string>en_US</string>\n")?;
+    write!(file, "  <key>UILaunchStoryboardName</key>\n  <string></string>\n")?;
 
 
     if !icon_filenames.is_empty() {


### PR DESCRIPTION
It looks like iOS [uses this field](https://stackoverflow.com/questions/56949674/uiwindow-not-filling-screen-for-new-devices) to determine if the app is a modern one that can support new device sizes; without it, the app content has a large black margin at the top and bottom of the app.

I feel like this is a reasonable flag to add to all apps, given how I can't imagine any production app would want to run in legacy cropped mode, but happy to try to convert this into a configuration parameter if that's not the case.

I tested this change by bundling an app and running on an iPhone 12 mini, and making sure this change fixed the cropping issue.

Fixes #91

Thanks for the great project! It's been working very well for me so far.