### PR TITLE
Add `/System/Library/Frameworks` to paths searched for Apple frameworks.

### DIFF
--- a/src/bundle/osx_bundle.rs
+++ b/src/bundle/osx_bundle.rs
@@ -190,7 +190,9 @@ fn copy_frameworks_to_bundle(bundle_directory: &Path, settings: &Settings)
         if copy_framework_from(&dest_dir, framework,
                                &PathBuf::from("/Library/Frameworks/"))? ||
            copy_framework_from(&dest_dir, framework,
-                               &PathBuf::from("/Network/Library/Frameworks/"))?
+                               &PathBuf::from("/Network/Library/Frameworks/"))? ||
+            copy_framework_from(&dest_dir, framework,
+                                &PathBuf::from("/System/Library/Frameworks/"))?
         {
             continue;
         }


### PR DESCRIPTION
On some versions of MacOS the default location of Apple frameworks is located at `/System/Library/Frameworks`. The documentation on Apple's [website](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/OSX_Technology_Overview/SystemFrameworks/SystemFrameworks.html) makes reference to this location. So here, I've just added it to the search paths.