### PR TITLE
Add support for URL schemes for macOS

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -107,6 +107,8 @@ These settings are used only when bundling `osx` packages.
   this config field, you may also want have your `build.rs` script emit
   `cargo:rustc-env=MACOSX_DEPLOYMENT_TARGET=10.11` (or whatever version number
   you want) to ensure that the compiled binary has the same minimum version.
+* `osx_url_schemes`: A list of strings indicating the URL schemes that the app
+  handles.
 
 ### Example `Cargo.toml`:
 
@@ -132,6 +134,7 @@ nisi ut aliquip ex ea commodo consequat.
 """
 deb_depends = ["libgl1-mesa-glx", "libsdl2-2.0-0 (>= 2.0.5)"]
 osx_frameworks = ["SDL2"]
+osx_url_schemes = ["com.doe.exampleapplication"]
 ```
 
 ## Contributing

--- a/src/bundle/osx_bundle.rs
+++ b/src/bundle/osx_bundle.rs
@@ -119,6 +119,26 @@ fn create_info_plist(bundle_dir: &Path, bundle_icon_file: Option<PathBuf>,
     write!(file,
            "  <key>CFBundleShortVersionString</key>\n  <string>{}</string>\n",
            settings.version_string())?;
+    if !settings.osx_url_schemes().is_empty() {
+        write!(file,
+            "  <key>CFBundleURLTypes</key>\n  \
+               <array>\n    \
+                   <dict>\n      \
+                       <key>CFBundleURLName</key>\n      \
+                       <string>{}</string>\n      \
+                       <key>CFBundleTypeRole</key>\n      \
+                       <string>Viewer</string>\n      \
+                       <key>CFBundleURLSchemes</key>\n      \
+                       <array>\n",
+            settings.bundle_name())?;
+        for scheme in settings.osx_url_schemes() {
+            write!(file, "        <string>{}</string>\n", scheme)?;
+        }
+        write!(file,
+            "      </array>\n    \
+                </dict>\n  \
+             </array>\n")?;
+    }
     write!(file,
            "  <key>CFBundleVersion</key>\n  <string>{}</string>\n",
            build_number)?;

--- a/src/bundle/settings.rs
+++ b/src/bundle/settings.rs
@@ -79,6 +79,7 @@ struct BundleSettings {
     deb_depends: Option<Vec<String>>,
     osx_frameworks: Option<Vec<String>>,
     osx_minimum_system_version: Option<String>,
+    osx_url_schemes: Option<Vec<String>>,
     // Bundles for other binaries/examples:
     bin: Option<HashMap<String, BundleSettings>>,
     example: Option<HashMap<String, BundleSettings>>,
@@ -432,6 +433,13 @@ impl Settings {
 
     pub fn osx_minimum_system_version(&self) -> Option<&str> {
         self.bundle_settings.osx_minimum_system_version.as_ref().map(String::as_str)
+    }
+
+    pub fn osx_url_schemes(&self) -> &[String] {
+        match self.bundle_settings.osx_url_schemes {
+            Some(ref urlosx_url_schemes) => urlosx_url_schemes.as_slice(),
+            None => &[],
+        }
     }
 }
 


### PR DESCRIPTION
Through the `osx_url_schemes` property, users can specify URL schemes that will be placed in Info.plist and then picked up by the system on app launch.

Related to #33