### PR TITLE
feat: support terminal app using cargo-bundle

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -75,6 +75,7 @@ These settings are used only when bundling Linux compatible packages (currently 
   field in the `.desktop` file. For example if the binary is called `my_program` and
   `linux_exec_args = "%f"` then the Exec filed will be `Exec=my_program %f`. Find out more from the
   [specification](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#exec-variables)
+* `linux_use_terminal`: A boolean variable indicating the app is a console app or a gui app, default it's set to false.
 
 ### Debian-specific settings
 

--- a/src/bundle/deb_bundle.rs
+++ b/src/bundle/deb_bundle.rs
@@ -129,7 +129,7 @@ fn generate_desktop_file(settings: &Settings, data_dir: &Path) -> ::Result<()> {
     write!(file, "Exec={}\n", exec)?;
     write!(file, "Icon={}\n", bin_name)?;
     write!(file, "Name={}\n", settings.bundle_name())?;
-    write!(file, "Terminal=false\n")?;
+    write!(file, "Terminal={}\n", settings.linux_use_terminal().unwrap_or(false))?;
     write!(file, "Type=Application\n")?;
     write!(file, "MimeType={}\n", mime_types)?;
     // The `Version` field is omitted on pupose. See `generate_control_file` for specifying

--- a/src/bundle/settings.rs
+++ b/src/bundle/settings.rs
@@ -76,6 +76,7 @@ struct BundleSettings {
     // OS-specific settings:
     linux_mime_types: Option<Vec<String>>,
     linux_exec_args: Option<String>,
+    linux_use_terminal: Option<bool>,
     deb_depends: Option<Vec<String>>,
     osx_frameworks: Option<Vec<String>>,
     osx_minimum_system_version: Option<String>,
@@ -287,6 +288,8 @@ impl Settings {
     /// Returns the path to the binary being bundled.
     pub fn binary_path(&self) -> &Path { &self.binary_path }
 
+    pub fn bundle_settings(&self) -> BundleSettings { self.bundle_settings.clone() }
+
     /// If a specific package type was specified by the command-line, returns
     /// that package type; otherwise, if a target triple was specified by the
     /// command-line, returns the native package type(s) for that target;
@@ -417,6 +420,10 @@ impl Settings {
             Some(ref mime_types) => mime_types.as_slice(),
             None => &[],
         }
+    }
+
+    pub fn linux_use_terminal(&self) -> Option<bool> {
+        self.bundle_settings.linux_use_terminal
     }
 
     pub fn linux_exec_args(&self) -> Option<&str> {


### PR DESCRIPTION
Currently, cargo bundle hard code `Terminal=false`, which is not fitted with console applications.
This PR introduces a new parameter called `linux_use_terminal`,  a boolean variable indicating the app is a console app or a gui app, default it's set to false.