### PR TITLE
Add option for copying keys into Info.plist on MacOS

### DIFF
--- a/src/bundle/osx_bundle.rs
+++ b/src/bundle/osx_bundle.rs
@@ -17,7 +17,7 @@
 // Currently, cargo-bundle does not support Frameworks, nor does it support placing arbitrary
 // files into the `Contents` directory of the bundle.
 
-use super::common;
+use super::common::{self, read_file};
 use crate::{ResultExt, Settings};
 
 use image::{self, GenericImage};
@@ -187,6 +187,14 @@ fn create_info_plist(
             file,
             "  <key>NSHumanReadableCopyright</key>\n  \
                 <string>{copyright}</string>\n"
+        )?;
+    }
+    for plist in settings.osx_info_plist_exts() {
+        let plist = plist?;
+        let contents  = read_file(&plist)?;
+        write!(
+            file,
+            "{contents}"
         )?;
     }
     write!(file, "</dict>\n</plist>\n")?;

--- a/src/bundle/settings.rs
+++ b/src/bundle/settings.rs
@@ -79,6 +79,7 @@ struct BundleSettings {
     osx_frameworks: Option<Vec<String>>,
     osx_minimum_system_version: Option<String>,
     osx_url_schemes: Option<Vec<String>>,
+    osx_info_plist_exts: Option<Vec<String>>,
     // Bundles for other binaries/examples:
     bin: Option<HashMap<String, BundleSettings>>,
     example: Option<HashMap<String, BundleSettings>>,
@@ -438,6 +439,14 @@ impl Settings {
         match self.bundle_settings.osx_url_schemes {
             Some(ref urlosx_url_schemes) => urlosx_url_schemes.as_slice(),
             None => &[],
+        }
+    }
+
+    /// Returns an iterator over the plist files for this bundle
+    pub fn osx_info_plist_exts(&self) -> ResourcePaths<'_> {
+        match self.bundle_settings.osx_info_plist_exts {
+            Some(ref paths) => ResourcePaths::new(paths.as_slice(), false),
+            None => ResourcePaths::new(&[], false),
         }
     }
 }


### PR DESCRIPTION
Hello!

We're building a local app and need to add some additional keys into our `Info.plist` for requesting access to system services like the microphone. So I decided to take a crack at implementing https://github.com/burtonageo/cargo-bundle/issues/33 for MacOS. 

Current implementation is simple: 
- It adds a `osx_info_plist_exts` field into the bundle settings,
- It reads each file in that path, and blindly appends it's contents into the `Info.plist` file, after `cargo-bundle` has generated it's keys but before it closes the `<dict>` and `<plist>`.

I haven't written documentation for this yet, as I imagine folks here will have some thoughts on the name and behavior for this.

Let me know what you think!