### PR TITLE
Add a flag for changing the package resolution technique

### DIFF
--- a/src/bundle/osx_bundle.rs
+++ b/src/bundle/osx_bundle.rs
@@ -17,7 +17,7 @@
 // Currently, cargo-bundle does not support Frameworks, nor does it support placing arbitrary
 // files into the `Contents` directory of the bundle.
 
-use super::common;
+use super::common::{self, read_file};
 use crate::{ResultExt, Settings};
 
 use image::{self, GenericImage};
@@ -187,6 +187,14 @@ fn create_info_plist(
             file,
             "  <key>NSHumanReadableCopyright</key>\n  \
                 <string>{copyright}</string>\n"
+        )?;
+    }
+    for plist in settings.osx_info_plist_exts() {
+        let plist = plist?;
+        let contents  = read_file(&plist)?;
+        write!(
+            file,
+            "{contents}"
         )?;
     }
     write!(file, "</dict>\n</plist>\n")?;

--- a/src/bundle/settings.rs
+++ b/src/bundle/settings.rs
@@ -79,6 +79,7 @@ struct BundleSettings {
     osx_frameworks: Option<Vec<String>>,
     osx_minimum_system_version: Option<String>,
     osx_url_schemes: Option<Vec<String>>,
+    osx_info_plist_exts: Option<Vec<String>>,
     // Bundles for other binaries/examples:
     bin: Option<HashMap<String, BundleSettings>>,
     example: Option<HashMap<String, BundleSettings>>,
@@ -438,6 +439,14 @@ impl Settings {
         match self.bundle_settings.osx_url_schemes {
             Some(ref urlosx_url_schemes) => urlosx_url_schemes.as_slice(),
             None => &[],
+        }
+    }
+
+    /// Returns an iterator over the plist files for this bundle
+    pub fn osx_info_plist_exts(&self) -> ResourcePaths<'_> {
+        match self.bundle_settings.osx_info_plist_exts {
+            Some(ref paths) => ResourcePaths::new(paths.as_slice(), false),
+            None => ResourcePaths::new(&[], false),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,6 +166,11 @@ fn run() -> crate::Result<()> {
                     Arg::with_name("no-default-features")
                         .long("no-default-features")
                         .help("Build a bundle without the default crate features."),
+                )
+                .arg(
+                    Arg::with_name("select-workspace-root")
+                        .long("select-workspace-root")
+                        .help("Selects the root package for parsing cargo.toml, according to the workspace's `cargo metadata`."),
                 ),
         )
         .get_matches();


### PR DESCRIPTION
This PR depends on: https://github.com/burtonageo/cargo-bundle/pull/147

In the process of integrating the previous PR's functionality, I realized that there's also a bug with package resolution in our Workspace's setup. This PR adds a flag to the bundle command to cause it to use the [`root_package()`](https://docs.rs/cargo_metadata/latest/cargo_metadata/struct.Metadata.html#method.root_package) method on Metadata.