### PR TITLE
Use `bin` target name instead of package name as default

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,8 +37,8 @@ There are several fields in the `[package.metadata.bundle]` section.
 
 These settings apply to bundles for all (or most) OSes.
 
- * `name`: The name of the built application. If this is not present, then it will use the `name` value from
-           your `Cargo.toml` file.
+ * `name`: The name of the built application. If this is not present, then it will use the `name` value from `bin`
+           target in your `Cargo.toml` file.
  * `identifier`: [REQUIRED] A string that uniquely identifies your application,
    in reverse-DNS form (for example, `"com.example.appname"` or
    `"io.github.username.project"`).  For OS X and iOS, this is used as the

--- a/src/bundle/settings.rs
+++ b/src/bundle/settings.rs
@@ -157,8 +157,17 @@ impl Settings {
             bail!("No [package.metadata.bundle] section in Cargo.toml");
         };
         let (bundle_settings, mut binary_name) = match build_artifact {
-            // TODO: this is wrong. Package can have multiple binaries and none of them has to be named the same way as package itself
-            BuildArtifact::Main => (bundle_settings, package.name.clone()),
+            BuildArtifact::Main => {
+                if let Some(target) = package
+                    .targets
+                    .iter()
+                    .find(|target| target.kind.iter().any(|k| k == "bin"))
+                {
+                    (bundle_settings, target.name.clone())
+                } else {
+                    bail!("No `bin` target is found in package '{}'", package.name)
+                }
+            }
             BuildArtifact::Bin(ref name) => (
                 bundle_settings_from_table(&bundle_settings.bin, "bin", name)?,
                 name.clone(),


### PR DESCRIPTION
Fixes #156