### PR TITLE
Add colocate flag for game bundling on MacOS

### DIFF
--- a/src/bundle/osx_bundle.rs
+++ b/src/bundle/osx_bundle.rs
@@ -56,7 +56,12 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
 
     for src in settings.resource_files() {
         let src = src?;
-        let dest = resources_dir.join(common::resource_relpath(&src));
+        let dest_dir = if settings.colocate() {
+            bundle_directory.join("MacOS")
+        } else {
+            resources_dir.clone()
+        };
+        let dest = dest_dir.join(common::resource_relpath(&src));
         common::copy_file(&src, &dest)
             .chain_err(|| format!("Failed to copy resource file {src:?}"))?;
     }

--- a/src/bundle/settings.rs
+++ b/src/bundle/settings.rs
@@ -67,6 +67,7 @@ struct BundleSettings {
     icon: Option<Vec<String>>,
     version: Option<String>,
     resources: Option<Vec<String>>,
+    colocate: Option<bool>,
     copyright: Option<String>,
     category: Option<AppCategory>,
     short_description: Option<String>,
@@ -360,6 +361,11 @@ impl Settings {
             Some(ref paths) => ResourcePaths::new(paths.as_slice(), true),
             None => ResourcePaths::new(&[], true),
         }
+    }
+
+    // TODO What does this flag do on non-MacOS OSes?
+    pub fn colocate(&self) -> bool {
+        self.bundle_settings.colocate.unwrap_or(false)
     }
 
     pub fn version_string(&self) -> &dyn Display {


### PR DESCRIPTION
Some game frameworks (well, I only checked Bevy and ggez) want resources to be colocated with the executable to load.

This adds a flag to indicate that resources should be located beside the executable, rather than in it's own directory, and implements that logic for MacOS.

#12 would also resolve this, but until then, this might be a nice middlestop for this usecase.