### PR TITLE
fix deb description + add Source field

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -144,6 +144,8 @@ osx_url_schemes = ["com.doe.exampleapplication"]
 `cargo-bundle` has ambitions to be inclusive project and welcome contributions from anyone.  Please abide by the Rust
 code of conduct.
 
+To install a local crate, run `cargo install --path .`
+
 ## Status
 
 Very early alpha. Expect the format of the `[package.metadata.bundle]` section to change, and there is no guarantee of

--- a/src/bundle/linux/deb_bundle.rs
+++ b/src/bundle/linux/deb_bundle.rs
@@ -131,6 +131,17 @@ fn generate_control_file(
     }
     writeln!(&mut file, "Description: {short_description}")?;
 
+    if let Some(long_description) = settings.long_description() {
+        for line in long_description.lines() {
+            let line = line.trim();
+            if line.is_empty() {
+                writeln!(&mut file, " .")?;
+            } else {
+                writeln!(&mut file, " {line}")?;
+            }
+        }
+    }
+
     if let Some(source) = &settings.package.repository {
         writeln!(&mut file, "Source: {source}")?;
     };

--- a/src/bundle/linux/deb_bundle.rs
+++ b/src/bundle/linux/deb_bundle.rs
@@ -129,19 +129,12 @@ fn generate_control_file(
     if short_description.is_empty() {
         short_description = "(none)";
     }
-    let mut long_description = settings.long_description().unwrap_or("").trim();
-    if long_description.is_empty() {
-        long_description = "(none)";
-    }
     writeln!(&mut file, "Description: {short_description}")?;
-    for line in long_description.lines() {
-        let line = line.trim();
-        if line.is_empty() {
-            writeln!(&mut file, " .")?;
-        } else {
-            writeln!(&mut file, " {line}")?;
-        }
-    }
+
+    if let Some(source) = &settings.package.repository {
+        writeln!(&mut file, "Source: {source}")?;
+    };
+
     file.flush()?;
     Ok(())
 }

--- a/src/bundle/settings.rs
+++ b/src/bundle/settings.rs
@@ -86,7 +86,7 @@ struct BundleSettings {
 
 #[derive(Clone, Debug)]
 pub struct Settings {
-    package: cargo_metadata::Package,
+    pub package: cargo_metadata::Package,
     package_type: Option<PackageType>, // If `None`, use the default package type for this os
     target: Option<(String, TargetInfo)>,
     features: Option<String>,


### PR DESCRIPTION
I think format will fail because long description is not used anymore, but could be use elsewhere