### PR TITLE
feat: respect CARGO_TARGET_DIR variable if set

### DIFF
--- a/src/bundle/settings.rs
+++ b/src/bundle/settings.rs
@@ -212,7 +212,9 @@ impl Settings {
         profile: &str,
         build_artifact: &BuildArtifact,
     ) -> PathBuf {
-        let mut path = project_root_dir.join("target");
+        let target_dir_env = std::env::var("CARGO_TARGET_DIR").map(PathBuf::from);
+        let mut path = target_dir_env.unwrap_or(project_root_dir.join("target"));
+
         if let &Some((ref triple, _)) = target {
             path.push(triple);
         }


### PR DESCRIPTION
note: this does not fix #161, since it doesn't read any `cargo.toml` config files.

The real fix is to use `cargo build --message-format json` and pick the correct artifact executable (like https://github.com/rust-lang/cargo/issues/6100#issuecomment-1435869969). I can do that in a follow-up PR but since it's probably a bit more controversial I wanted to open this simple fix first.