### PR TITLE
Choose a default identifier for examples and binaries

### DIFF
--- a/src/bundle/settings.rs
+++ b/src/bundle/settings.rs
@@ -2,6 +2,7 @@ use super::category::AppCategory;
 use clap::ArgMatches;
 
 use cargo_metadata::{Metadata, MetadataCommand};
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::path::{Path, PathBuf};
@@ -356,8 +357,18 @@ impl Settings {
             .unwrap_or(&self.package.name)
     }
 
-    pub fn bundle_identifier(&self) -> &str {
-        self.bundle_settings.identifier.as_deref().unwrap_or("")
+    pub fn bundle_identifier(&self) -> Cow<'_, str> {
+        if let Some(identifier) = &self.bundle_settings.identifier {
+            identifier.into()
+        } else {
+            match &self.build_artifact {
+                BuildArtifact::Main => "".into(),
+                BuildArtifact::Bin(name) => format!("{name}.{}", self.package.name).into(),
+                BuildArtifact::Example(name) => {
+                    format!("{name}.example.{}", self.package.name).into()
+                }
+            }
+        }
     }
 
     /// Returns an iterator over the icon files to be used for this bundle.


### PR DESCRIPTION
These are by far not correct, but probably still better than having an empty bundle identifier.