### PR TITLE
Release a new version (`v0.6.1`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-bundle"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "ar",
  "cab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-bundle"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["George Burton <burtonageo@gmail.com>"]
 license = "MIT OR Apache-2.0"
 keywords = ["bundle", "cargo"]


### PR DESCRIPTION
I've compiled the user-facing changelog to be:
- macOS: Add support for URL schemes (#123)
- Linux: Support stating that the application is a terminal application (#124)
- iOS: Fix mismatch of the executable name in Info.plist and its real name (#127)
- Windows: Fix MSI support and add a minimal UI to the installer (#142)
- Find package which has `[package.metadata.bundle]` section in workspace (#155)
- Use `bin` target name instead of package name, if no other name was specified (#157)
- Linux: Fix `Installed-Size` (#160)
- The current working directory is now also considered a workspace root (#176)
- Allow building with a custom Cargo toolchain (#175)
- Respect `CARGO_TARGET_DIR` variable if set (#178)
- Allow missing `package.metadata.bundle` section (#183)
- Choose a default identifier for examples and binaries (#182)

From what I can see, none of these are breaking, which is why I chose to only bump the patch version.

CC @mdsteele
