### PR TITLE
implement ability to copy osx plugins

### DIFF
--- a/src/bundle/osx_bundle.rs
+++ b/src/bundle/osx_bundle.rs
@@ -55,8 +55,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
     copy_frameworks_to_bundle(&bundle_directory, settings)
         .chain_err(|| "Failed to bundle frameworks")?;
 
-    copy_plugins_to_bundle(&bundle_directory, settings)
-        .chain_err(|| "Failed to bundle plugins")?;
+    copy_plugins_to_bundle(&bundle_directory, settings).chain_err(|| "Failed to bundle plugins")?;
 
     for src in settings.resource_files() {
         let src = src?;

--- a/src/bundle/osx_bundle.rs
+++ b/src/bundle/osx_bundle.rs
@@ -9,6 +9,7 @@
 //         Resources      # Data files such as images, sounds, translations and nib files
 //             en.lproj        # Folder containing english translation strings/data
 //         Frameworks     # A directory containing private frameworks (shared libraries)
+//         PlugIns        # A directory containing Plugins
 //         ...            # Any other optional files the developer wants to place here
 //
 // See https://developer.apple.com/go/?id=bundle-structure for a full
@@ -53,6 +54,9 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
 
     copy_frameworks_to_bundle(&bundle_directory, settings)
         .chain_err(|| "Failed to bundle frameworks")?;
+
+    copy_plugins_to_bundle(&bundle_directory, settings)
+        .chain_err(|| "Failed to bundle plugins")?;
 
     for src in settings.resource_files() {
         let src = src?;
@@ -268,6 +272,22 @@ fn copy_frameworks_to_bundle(bundle_directory: &Path, settings: &Settings) -> cr
             continue;
         }
         bail!("Could not locate {}.framework", framework);
+    }
+    Ok(())
+}
+
+fn copy_plugins_to_bundle(bundle_directory: &Path, settings: &Settings) -> crate::Result<()> {
+    let plugins = settings.osx_plugins();
+    if plugins.is_empty() {
+        return Ok(());
+    }
+    let dest_dir = bundle_directory.join("PlugIns");
+    fs::create_dir_all(bundle_directory)
+        .chain_err(|| format!("Failed to create PlugIns directory at {dest_dir:?}"))?;
+    for plugin in plugins.iter() {
+        let src_path = PathBuf::from(plugin);
+        let src_name = src_path.file_name().unwrap();
+        common::copy_dir(&src_path, &dest_dir.join(src_name))?;
     }
     Ok(())
 }

--- a/src/bundle/settings.rs
+++ b/src/bundle/settings.rs
@@ -81,6 +81,7 @@ struct BundleSettings {
     linux_use_terminal: Option<bool>,
     deb_depends: Option<Vec<String>>,
     osx_frameworks: Option<Vec<String>>,
+    osx_plugins: Option<Vec<String>>,
     osx_minimum_system_version: Option<String>,
     osx_url_schemes: Option<Vec<String>>,
     osx_info_plist_exts: Option<Vec<String>>,
@@ -475,6 +476,13 @@ impl Settings {
     pub fn osx_frameworks(&self) -> &[String] {
         match self.bundle_settings.osx_frameworks {
             Some(ref frameworks) => frameworks.as_slice(),
+            None => &[],
+        }
+    }
+
+    pub fn osx_plugins(&self) -> &[String] {
+        match self.bundle_settings.osx_plugins {
+            Some(ref plugins) => plugins.as_slice(),
             None => &[],
         }
     }


### PR DESCRIPTION
This is useful for Quicklook plugins (`.appex`) and similar. They do not go into the Frameworks or Resources directory but in their own PlugIns directory