### PR TITLE
feat: Add `bundle-type` argument to `bundle` command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -149,6 +149,12 @@ fn run() -> crate::Result<()> {
                         .help("Build a bundle from a target build using the given profile"),
                 )
                 .arg(
+                    Arg::with_name("bundle-type")
+                        .long("bundle-type")
+                        .value_name("NAME")
+                        .help("Build a bundle of the specified type"),
+                )
+                .arg(
                     Arg::with_name("target")
                         .long("target")
                         .value_name("TRIPLE")


### PR DESCRIPTION
First of all, we are very grateful for the `cargo-bundle` project, it has really helped us save a lot of time.

We are currently encountering an issue where our project may require multiple configurations. They have different names and different icons. I added a parameter called `bundle-type`, and if it is specified when executing the `bundle` command, the configuration specified by `package.metadata.bundle.[bundle-type]` will be used.

What do you think?