### PR TITLE
implement ability to copy osx plugins

### DIFF
--- a/src/bundle/settings.rs
+++ b/src/bundle/settings.rs
@@ -108,6 +108,7 @@ struct BundleSettings {
     linux_use_terminal: Option<bool>,
     deb_depends: Option<Vec<String>>,
     osx_frameworks: Option<Vec<String>>,
+    osx_plugins: Option<Vec<String>>,
     osx_minimum_system_version: Option<String>,
     osx_url_schemes: Option<Vec<String>>,
     osx_info_plist_exts: Option<Vec<String>>,
@@ -492,6 +493,13 @@ impl Settings {
     pub fn osx_frameworks(&self) -> &[String] {
         match self.bundle_settings.osx_frameworks {
             Some(ref frameworks) => frameworks.as_slice(),
+            None => &[],
+        }
+    }
+
+    pub fn osx_plugins(&self) -> &[String] {
+        match self.bundle_settings.osx_plugins {
+            Some(ref plugins) => plugins.as_slice(),
             None => &[],
         }
     }


### PR DESCRIPTION
This PR will close burtonageo/cargo-bundle#193

This is useful for Quicklook plugins (.appex) and similar. They do not go into the Frameworks or Resources directory but in their own PlugIns directory

Hi @mdsteele please review this PR.
