### PR TITLE
Linux Localization/Desktop Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ chrono = "0.4.44"
 clap = { version = "4.5.60", features = ["derive", "wrap_help", "cargo"] }
 dirs = "6.0.0"
 glob = "0.3.3"
+goblin = "0.10"
 icns = "0.4.0"
 image = { version = "0.25.10", features = ["png"] }
 libflate = "2.2.1"

--- a/Readme.md
+++ b/Readme.md
@@ -105,6 +105,59 @@ These settings are used only when bundling Linux compatible packages (currently 
   `linux_exec_args = "%f"` then the Exec filed will be `Exec=my_program %f`. Find out more from the
   [specification](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#exec-variables)
 * `linux_use_terminal`: A boolean variable indicating the app is a console app or a gui app, default it's set to false.
+* `linux_localizations`: Per-locale translations for FreeDesktop `.desktop` entry fields.
+  Mirrors the shape of `osx_localizations`: each sub-table is a locale code
+  (`fr`, `de`, `pt_BR`, `zh_CN`, …) containing optional FreeDesktop
+  [localestring](https://specifications.freedesktop.org/desktop-entry-spec/latest/recognized-keys.html)
+  keys. Supported keys:
+
+  * `Name` -- translated application name (`Name[fr]=…`)
+  * `GenericName` -- generic type name, e.g. “Web Browser”
+  * `Comment` -- short description / tooltip
+  * `Keywords` -- search keywords; either a semicolon-separated string
+    (`"outil;utilitaire"`) or a TOML list (`["outil", "utilitaire"]`), both
+    emitted with a trailing `;` per the Desktop Entry Spec
+  * `Icon` — locale-specific icon name (`Icon[locale]=…`; rarely needed)
+
+  Locale codes may include an encoding part (`fr.UTF-8`); it is stripped when
+  rendering, since desktop files are always UTF-8.
+
+  Unlocalized `Name` and `Comment` still come from `name` / `short_description`
+  (or the package description). If only localized `GenericName` / `Keywords`
+  are provided, the unlocalized base value is taken from the `C` or `en`
+  locale when present, otherwise from the first locale in sorted order
+  (FreeDesktop requires an unlocalized key whenever any `Key[locale]` is
+  present).
+
+  Example:
+
+  ```toml
+  [package.metadata.bundle.linux_localizations.fr]
+  Name = "Mon App"
+  Comment = "Une description"
+  GenericName = "Utilitaire"
+  Keywords = ["outil", "utilitaire"]
+
+  [package.metadata.bundle.linux_localizations.de]
+  Name = "Meine App"
+  Comment = "Eine Beschreibung"
+  Keywords = "werkzeug;dienstprogramm"
+  ```
+* `linux_startup_wm_class`: [OPTIONAL] Value for the `StartupWMClass` key of the `.desktop`
+  file, used by desktop environments to match running windows to the launcher entry.
+* `linux_desktop_actions`: [OPTIONAL] Additional application actions (e.g. "New Window")
+  shown in launcher context menus, emitted as `[Desktop Action <id>]` groups. Each sub-table
+  key is an action id; `Name` is required, `Exec` defaults to the app binary, `Icon` and
+  per-locale `NameLocalized` are optional:
+
+  ```toml
+  [package.metadata.bundle.linux_desktop_actions.new-window]
+  Name = "New Window"
+  Exec = "myapp --new-window"
+
+  [package.metadata.bundle.linux_desktop_actions.new-window.NameLocalized]
+  fr = "Nouvelle fenêtre"
+  ```
 
 ### Debian-specific settings
 

--- a/src/bundle/linux/appimage_bundle.rs
+++ b/src/bundle/linux/appimage_bundle.rs
@@ -14,7 +14,7 @@ use resvg::usvg::{Options, Tree};
 
 use crate::bundle::{Settings, common};
 
-use super::common::{generate_desktop_file, generate_icon_files};
+use super::{DesktopFileOptions, generate_desktop_file, generate_icon_files};
 
 pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
     let package_base_name = format!(
@@ -39,7 +39,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
     let binary_dest_abs = app_dir.join(binary_dest_rel.clone());
     common::copy_file(settings.binary_path(), &binary_dest_abs)?;
     generate_icon_files(settings, &app_dir)?;
-    generate_desktop_file(settings, &app_dir)?;
+    generate_desktop_file(settings, &app_dir, &DesktopFileOptions::default())?;
 
     common::symlink_file(&binary_dest_rel, &app_dir.join("AppRun"))?;
 

--- a/src/bundle/linux/common.rs
+++ b/src/bundle/linux/common.rs
@@ -1,55 +1,13 @@
-use crate::bundle::{Settings, common};
-use image::GenericImageView;
+//! Shared Linux packaging utilities (archives, checksums, small file helpers).
+
+use crate::bundle::common;
 use libflate::gzip;
 use md5::Digest;
-use std::collections::BTreeSet;
-use std::ffi::OsStr;
 use std::fs::File;
 use std::io;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
-
-/// Generate the application desktop file and store it under the `data_dir`.
-pub fn generate_desktop_file(settings: &Settings, data_dir: &Path) -> crate::Result<()> {
-    let bin_name = settings.binary_name();
-    let desktop_file_name = format!("{bin_name}.desktop");
-    let desktop_file_path = data_dir
-        .join("usr/share/applications")
-        .join(desktop_file_name);
-    let file = &mut common::create_file(&desktop_file_path)?;
-    let mime_types = settings
-        .linux_mime_types()
-        .iter()
-        .fold("".to_owned(), |acc, s| format!("{acc}{s};"));
-    // For more information about the format of this file, see
-    // https://developer.gnome.org/integration-guide/stable/desktop-files.html.en
-    writeln!(file, "[Desktop Entry]")?;
-    writeln!(file, "Encoding=UTF-8")?;
-    if let Some(category) = settings.app_category() {
-        writeln!(file, "Categories={}", category.gnome_desktop_categories())?;
-    }
-    if !settings.short_description().is_empty() {
-        writeln!(file, "Comment={}", settings.short_description())?;
-    }
-    let exec = match settings.linux_exec_args() {
-        Some(args) => format!("{bin_name} {args}"),
-        None => bin_name.to_owned(),
-    };
-    writeln!(file, "Exec={exec}")?;
-    writeln!(file, "Icon={bin_name}")?;
-    writeln!(file, "Name={}", settings.bundle_name())?;
-    writeln!(
-        file,
-        "Terminal={}",
-        settings.linux_use_terminal().unwrap_or(false)
-    )?;
-    writeln!(file, "Type=Application")?;
-    writeln!(file, "MimeType={mime_types}")?;
-    // The `Version` field is omitted on pupose. See `generate_control_file` for specifying
-    // the application version.
-    Ok(())
-}
 
 /// Creates a `.tar.gz` file from the given directory (placing the new file
 /// within the given directory's parent directory), then deletes the original
@@ -104,120 +62,6 @@ pub fn total_dir_size(dir: &Path) -> crate::Result<u64> {
         total += entry?.metadata()?.len();
     }
     Ok(total)
-}
-
-fn get_dest_path<'a>(
-    width: u32,
-    height: u32,
-    is_high_density: bool,
-    base_dir: &'a Path,
-    binary_name: &'a str,
-) -> PathBuf {
-    Path::join(
-        base_dir,
-        format!(
-            "{}x{}{}/apps/{}.png",
-            width,
-            height,
-            if is_high_density { "@2x" } else { "" },
-            binary_name
-        ),
-    )
-}
-
-fn generate_icon_files_png(
-    icon_path: &PathBuf,
-    base_dir: &Path,
-    binary_name: &str,
-    mut sizes: BTreeSet<(u32, u32, bool)>,
-) -> crate::Result<BTreeSet<(u32, u32, bool)>> {
-    let img = image::ImageReader::open(icon_path)?
-        .with_guessed_format()?
-        .decode()?;
-    let (width, height) = img.dimensions();
-    let is_high_density = common::is_retina(icon_path);
-
-    if !sizes.contains(&(width, height, is_high_density)) {
-        sizes.insert((width, height, is_high_density));
-        let dest_path = get_dest_path(width, height, is_high_density, base_dir, binary_name);
-        common::copy_file(icon_path, &dest_path)?;
-    }
-
-    Ok(sizes.to_owned())
-}
-
-fn generate_icon_files_non_png(
-    icon_path: &PathBuf,
-    base_dir: &Path,
-    binary_name: &str,
-    mut sizes: BTreeSet<(u32, u32, bool)>,
-) -> crate::Result<BTreeSet<(u32, u32, bool)>> {
-    if icon_path.extension() == Some(OsStr::new("icns")) {
-        let icon_family = icns::IconFamily::read(File::open(icon_path)?)?;
-        for icon_type in icon_family.available_icons() {
-            let width = icon_type.screen_width();
-            let height = icon_type.screen_height();
-            let is_high_density = icon_type.pixel_density() > 1;
-
-            if !sizes.contains(&(width, height, is_high_density)) {
-                sizes.insert((width, height, is_high_density));
-                let icon = icon_family.get_icon_with_type(icon_type)?;
-                let dest_path =
-                    get_dest_path(width, height, is_high_density, base_dir, binary_name);
-                icon.write_png(common::create_file(&dest_path)?)?;
-            }
-        }
-    } else {
-        let icon = image::open(icon_path)?;
-        let (width, height) = icon.dimensions();
-        let is_high_density = common::is_retina(icon_path);
-
-        if !sizes.contains(&(width, height, is_high_density)) {
-            sizes.insert((width, height, is_high_density));
-            let dest_path = get_dest_path(width, height, is_high_density, base_dir, binary_name);
-            let mut file = common::create_file(&dest_path)?;
-            icon.write_to(&mut file, image::ImageFormat::Png)?;
-        }
-    }
-
-    Ok(sizes.to_owned())
-}
-
-/// Generate the icon files and store them under the `data_dir`.
-pub fn generate_icon_files(settings: &Settings, data_dir: &Path) -> crate::Result<()> {
-    let base_dir = data_dir.join("usr/share/icons/hicolor");
-
-    let mut sizes: BTreeSet<(u32, u32, bool)> = BTreeSet::new();
-
-    for icon_path in settings.icon_files() {
-        let icon_path = icon_path?;
-        if icon_path.extension() == Some(OsStr::new("svg")) {
-            let scalable_dir = base_dir.join("scalable/apps");
-            std::fs::create_dir_all(&scalable_dir)?;
-            let dest_path = scalable_dir.join(format!("{}.svg", settings.binary_name()));
-            common::copy_file(&icon_path, &dest_path)?;
-        } else if icon_path.extension() == Some(OsStr::new("png")) {
-            let new_sizes = generate_icon_files_png(
-                &icon_path,
-                &base_dir,
-                settings.binary_name(),
-                sizes.clone(),
-            )
-            .unwrap();
-            sizes.append(&mut new_sizes.to_owned())
-        } else {
-            let new_sizes = generate_icon_files_non_png(
-                &icon_path,
-                &base_dir,
-                settings.binary_name(),
-                sizes.clone(),
-            )
-            .unwrap();
-            sizes.append(&mut new_sizes.to_owned())
-        }
-    }
-
-    Ok(())
 }
 
 /// Compute the md5 hash of the given file.

--- a/src/bundle/linux/deb_bundle.rs
+++ b/src/bundle/linux/deb_bundle.rs
@@ -20,9 +20,9 @@
 
 use crate::bundle::{
     Settings, common,
-    linux::common::{
-        create_file_with_data, generate_desktop_file, generate_icon_files, generate_md5sum,
-        tar_and_gzip_dir, total_dir_size,
+    linux::{
+        DesktopFileOptions, create_file_with_data, generate_desktop_file, generate_icon_files,
+        generate_md5sum, tar_and_gzip_dir, total_dir_size,
     },
 };
 use anyhow::Context;
@@ -63,7 +63,8 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
     transfer_resource_files(settings, &data_dir)
         .with_context(|| "Failed to copy resource files")?;
     generate_icon_files(settings, &data_dir).with_context(|| "Failed to create icon files")?;
-    generate_desktop_file(settings, &data_dir).with_context(|| "Failed to create desktop file")?;
+    generate_desktop_file(settings, &data_dir, &DesktopFileOptions::default())
+        .with_context(|| "Failed to create desktop file")?;
 
     // Generate control files.
     let control_dir = package_dir.join("control");

--- a/src/bundle/linux/desktop.rs
+++ b/src/bundle/linux/desktop.rs
@@ -1,0 +1,491 @@
+//! FreeDesktop `.desktop` Application entry generation.
+
+use crate::bundle::localization::{LinuxDesktopLocalizations, escape_desktop_value};
+use crate::bundle::settings::DesktopAction;
+use crate::bundle::{Settings, common};
+use std::collections::{BTreeMap, HashMap};
+use std::io::Write;
+use std::path::Path;
+
+/// Per-package-format options for `.desktop` generation that don't come from
+/// bundle settings.
+#[derive(Debug, Default)]
+pub struct DesktopFileOptions {
+    /// Available so appimaged/AppImageLauncher can
+    /// distinguish integrated versions
+    pub appimage_version: Option<String>,
+}
+
+/// Inputs needed to render a FreeDesktop `.desktop` Application entry.
+/// Kept separate from [`Settings`] so unit tests need not construct a full
+/// Cargo package.
+#[derive(Debug)]
+struct DesktopEntryInput<'a> {
+    bin_name: &'a str,
+    app_name: &'a str,
+    comment: &'a str,
+    categories: Option<&'a str>,
+    exec_args: Option<&'a str>,
+    use_terminal: bool,
+    mime_types: &'a [String],
+    localizations: Option<LinuxDesktopLocalizations<'a>>,
+    startup_wm_class: Option<&'a str>,
+    appimage_version: Option<&'a str>,
+    actions: Option<&'a HashMap<String, DesktopAction>>,
+}
+
+/// Render a FreeDesktop `.desktop` Application entry as a string.
+fn render_desktop_entry(input: &DesktopEntryInput<'_>) -> String {
+    use std::fmt::Write as _;
+
+    let mut out = String::new();
+
+    // For more information about the format of this file, see
+    // https://specifications.freedesktop.org/desktop-entry-spec/latest/
+    //
+    // Encoding=UTF-8 is omitted: the key is deprecated (files are UTF-8 by
+    // definition in modern Desktop Entry Spec versions).
+    writeln!(out, "[Desktop Entry]").unwrap();
+    if let Some(categories) = input.categories {
+        writeln!(out, "Categories={categories}").unwrap();
+    }
+
+    // Comment: unlocalized base is required if any Comment[locale] is present.
+    let needs_comment_fallback = input
+        .localizations
+        .as_ref()
+        .is_some_and(|l| l.has_localized_comment());
+
+    if !input.comment.is_empty() {
+        writeln!(out, "Comment={}", escape_desktop_value(input.comment)).unwrap();
+    } else if needs_comment_fallback
+        && let Some(fallback) = input
+            .localizations
+            .as_ref()
+            .and_then(|l| l.fallback_comment())
+    {
+        writeln!(out, "Comment={}", escape_desktop_value(fallback)).unwrap();
+    }
+
+    match input.exec_args {
+        Some(args) => writeln!(out, "Exec={} {}", input.bin_name, args).unwrap(),
+        None => writeln!(out, "Exec={}", input.bin_name).unwrap(),
+    }
+
+    writeln!(out, "Icon={}", input.bin_name).unwrap();
+    writeln!(out, "Name={}", escape_desktop_value(input.app_name)).unwrap();
+
+    // GenericName / Keywords bases + all Key[locale]=… lines.
+    if let Some(locs) = &input.localizations {
+        locs.append_desktop_keys(&mut out);
+    }
+
+    writeln!(out, "Terminal={}", input.use_terminal).unwrap();
+    writeln!(out, "Type=Application").unwrap();
+
+    if let Some(wm_class) = input.startup_wm_class {
+        writeln!(out, "StartupWMClass={}", escape_desktop_value(wm_class)).unwrap();
+    }
+
+    if let Some(version) = input.appimage_version {
+        writeln!(out, "X-AppImage-Version={}", escape_desktop_value(version)).unwrap();
+    }
+
+    // Omit empty MimeType; a bare `MimeType=` is noise and fails some validators.
+    if !input.mime_types.is_empty() {
+        write!(out, "MimeType=").unwrap();
+        for mime in input.mime_types {
+            write!(out, "{mime};").unwrap();
+        }
+        writeln!(out).unwrap();
+    }
+
+    // Desktop Actions: `Actions=` list in the main group (sorted for stable
+    // diffs), then one `[Desktop Action <id>]` group per action.
+    let sorted_actions: BTreeMap<&str, &DesktopAction> = input
+        .actions
+        .into_iter()
+        .flatten()
+        .map(|(id, action)| (id.as_str(), action))
+        .collect();
+
+    if !sorted_actions.is_empty() {
+        write!(out, "Actions=").unwrap();
+        for id in sorted_actions.keys() {
+            write!(out, "{id};").unwrap();
+        }
+        writeln!(out).unwrap();
+    }
+
+    for (id, action) in &sorted_actions {
+        writeln!(out).unwrap();
+        writeln!(out, "[Desktop Action {id}]").unwrap();
+        writeln!(out, "Name={}", escape_desktop_value(&action.name)).unwrap();
+        if let Some(localized) = &action.name_localized {
+            let sorted: BTreeMap<&str, &String> = localized
+                .iter()
+                .map(|(locale, name)| (locale.as_str(), name))
+                .collect();
+            for (locale, name) in sorted {
+                writeln!(out, "Name[{locale}]={}", escape_desktop_value(name)).unwrap();
+            }
+        }
+        let exec = action.exec.as_deref().unwrap_or(input.bin_name);
+        writeln!(out, "Exec={exec}").unwrap();
+        if let Some(icon) = &action.icon {
+            writeln!(out, "Icon={}", escape_desktop_value(icon)).unwrap();
+        }
+    }
+
+    // The `Version` field is omitted on purpose. See `generate_control_file` for
+    // specifying the application version (Desktop Entry `Version` is the spec
+    // version, not the app version).
+    out
+}
+
+/// Generate the application desktop file and store it under the `data_dir`.
+pub fn generate_desktop_file(
+    settings: &Settings,
+    data_dir: &Path,
+    options: &DesktopFileOptions,
+) -> crate::Result<()> {
+    let bin_name = settings.binary_name();
+    let desktop_file_name = format!("{bin_name}.desktop");
+    let desktop_file_path = data_dir
+        .join("usr/share/applications")
+        .join(desktop_file_name);
+    let file = &mut common::create_file(&desktop_file_path)?;
+
+    // desktop-file-validate and appimagetool both expect a Categories key;
+    // default to Utility when the manifest doesn't set one.
+    let categories = match settings.app_category() {
+        Some(category) => category.gnome_desktop_categories().to_string(),
+        None => {
+            let _ = common::print_warning(
+                "No category set in bundle settings; defaulting to Categories=Utility; \
+                 in the .desktop file. Set `category` in [package.metadata.bundle] to \
+                 pick a proper one.",
+            );
+            "Utility;".to_string()
+        }
+    };
+
+    let contents = render_desktop_entry(&DesktopEntryInput {
+        bin_name,
+        app_name: settings.bundle_name(),
+        comment: settings.short_description(),
+        categories: Some(&categories),
+        exec_args: settings.linux_exec_args(),
+        use_terminal: settings.linux_use_terminal().unwrap_or(false),
+        mime_types: settings.linux_mime_types(),
+        localizations: settings.linux_localizations(),
+        startup_wm_class: settings.linux_startup_wm_class(),
+        appimage_version: options.appimage_version.as_deref(),
+        actions: settings.linux_desktop_actions(),
+    });
+
+    file.write_all(contents.as_bytes())?;
+    file.flush()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bundle::localization::{DesktopKeywords, LinuxDesktopLocale};
+    use std::collections::HashMap;
+
+    #[test]
+    fn desktop_entry_basic_without_localizations() {
+        let mime = vec!["text/plain".to_string()];
+        let contents = render_desktop_entry(&DesktopEntryInput {
+            bin_name: "myapp",
+            app_name: "My App",
+            comment: "A short description",
+            categories: Some("Utility;"),
+            exec_args: Some("%f"),
+            use_terminal: false,
+            mime_types: &mime,
+            localizations: None,
+            startup_wm_class: None,
+            appimage_version: None,
+            actions: None,
+        });
+
+        assert!(contents.starts_with("[Desktop Entry]\n"));
+        assert!(!contents.contains("Encoding="));
+        assert!(contents.contains("Categories=Utility;\n"));
+        assert!(contents.contains("Comment=A short description\n"));
+        assert!(contents.contains("Exec=myapp %f\n"));
+        assert!(contents.contains("Icon=myapp\n"));
+        assert!(contents.contains("Name=My App\n"));
+        assert!(contents.contains("Terminal=false\n"));
+        assert!(contents.contains("Type=Application\n"));
+        assert!(contents.contains("MimeType=text/plain;\n"));
+        assert!(!contents.contains("Name["));
+    }
+
+    #[test]
+    fn desktop_entry_omits_empty_mime_type() {
+        let contents = render_desktop_entry(&DesktopEntryInput {
+            bin_name: "myapp",
+            app_name: "My App",
+            comment: "",
+            categories: None,
+            exec_args: None,
+            use_terminal: true,
+            mime_types: &[],
+            localizations: None,
+            startup_wm_class: None,
+            appimage_version: None,
+            actions: None,
+        });
+        assert!(!contents.contains("MimeType"));
+        assert!(contents.contains("Terminal=true\n"));
+        assert!(!contents.contains("Comment="));
+    }
+
+    #[test]
+    fn desktop_entry_with_multiple_locales() {
+        let mut locs = HashMap::new();
+        locs.insert(
+            "fr".to_string(),
+            LinuxDesktopLocale {
+                icon: None,
+                name: Some("Mon App".into()),
+                comment: Some("Une description".into()),
+                generic_name: Some("Utilitaire".into()),
+                keywords: Some(DesktopKeywords::List(vec![
+                    "outil".into(),
+                    "utilitaire".into(),
+                ])),
+            },
+        );
+        locs.insert(
+            "de".to_string(),
+            LinuxDesktopLocale {
+                icon: None,
+                name: Some("Meine App".into()),
+                comment: Some("Eine Beschreibung".into()),
+                generic_name: Some("Dienstprogramm".into()),
+                keywords: Some(DesktopKeywords::String("werkzeug;dienstprogramm".into())),
+            },
+        );
+        locs.insert(
+            "pt_BR".to_string(),
+            LinuxDesktopLocale {
+                icon: None,
+                name: Some("Meu App".into()),
+                comment: Some("Uma descrição".into()),
+                generic_name: None,
+                keywords: None,
+            },
+        );
+
+        let contents = render_desktop_entry(&DesktopEntryInput {
+            bin_name: "myapp",
+            app_name: "My App",
+            comment: "A short description",
+            categories: Some("Utility;"),
+            exec_args: None,
+            use_terminal: false,
+            mime_types: &[],
+            localizations: Some(LinuxDesktopLocalizations::new(&locs)),
+            startup_wm_class: None,
+            appimage_version: None,
+            actions: None,
+        });
+
+        assert!(contents.contains("Name=My App\n"));
+        assert!(contents.contains("Comment=A short description\n"));
+        assert!(contents.contains("GenericName=Dienstprogramm\n"));
+        assert!(contents.contains("Keywords=werkzeug;dienstprogramm;\n"));
+        assert!(contents.contains("Name[de]=Meine App\n"));
+        assert!(contents.contains("Name[fr]=Mon App\n"));
+        assert!(contents.contains("Name[pt_BR]=Meu App\n"));
+        assert!(!contents.contains("GenericName[pt_BR]"));
+
+        let de_pos = contents.find("Name[de]=").unwrap();
+        let fr_pos = contents.find("Name[fr]=").unwrap();
+        let pt_pos = contents.find("Name[pt_BR]=").unwrap();
+        assert!(de_pos < fr_pos && fr_pos < pt_pos);
+    }
+
+    #[test]
+    fn desktop_entry_prefers_en_for_unlocalized_generic_name() {
+        let mut locs = HashMap::new();
+        locs.insert(
+            "fr".to_string(),
+            LinuxDesktopLocale {
+                icon: None,
+                name: Some("Mon App".into()),
+                generic_name: Some("Utilitaire".into()),
+                comment: None,
+                keywords: None,
+            },
+        );
+        locs.insert(
+            "en".to_string(),
+            LinuxDesktopLocale {
+                icon: None,
+                name: Some("My App".into()),
+                generic_name: Some("Utility".into()),
+                comment: None,
+                keywords: None,
+            },
+        );
+
+        let contents = render_desktop_entry(&DesktopEntryInput {
+            bin_name: "myapp",
+            app_name: "My App",
+            comment: "",
+            categories: None,
+            exec_args: None,
+            use_terminal: false,
+            mime_types: &[],
+            localizations: Some(LinuxDesktopLocalizations::new(&locs)),
+            startup_wm_class: None,
+            appimage_version: None,
+            actions: None,
+        });
+
+        assert!(contents.contains("GenericName=Utility\n"));
+        assert!(contents.contains("GenericName[en]=Utility\n"));
+        assert!(contents.contains("GenericName[fr]=Utilitaire\n"));
+    }
+
+    #[test]
+    fn desktop_entry_escapes_values_and_keyword_semicolons() {
+        let mut locs = HashMap::new();
+        locs.insert(
+            "fr".to_string(),
+            LinuxDesktopLocale {
+                icon: None,
+                name: Some("App\\Name".into()),
+                comment: Some("line1\nline2".into()),
+                generic_name: None,
+                keywords: Some(DesktopKeywords::List(vec!["a;b".into(), "c".into()])),
+            },
+        );
+
+        let contents = render_desktop_entry(&DesktopEntryInput {
+            bin_name: "myapp",
+            app_name: "Name\\With\\Backslash",
+            comment: "has\ttab",
+            categories: None,
+            exec_args: None,
+            use_terminal: false,
+            mime_types: &[],
+            localizations: Some(LinuxDesktopLocalizations::new(&locs)),
+            startup_wm_class: None,
+            appimage_version: None,
+            actions: None,
+        });
+
+        assert!(contents.contains(r"Name=Name\\With\\Backslash"));
+        assert!(contents.contains(r"Comment=has\ttab"));
+        assert!(contents.contains(r"Name[fr]=App\\Name"));
+        assert!(contents.contains(r"Comment[fr]=line1\nline2"));
+        assert!(contents.contains(r"Keywords[fr]=a\;b;c;"));
+    }
+
+    #[test]
+    fn locales_are_sorted() {
+        let mut locs = HashMap::new();
+        locs.insert("fr".to_string(), LinuxDesktopLocale::default());
+        locs.insert("de".to_string(), LinuxDesktopLocale::default());
+        let table = LinuxDesktopLocalizations::new(&locs);
+        let sorted: Vec<_> = table.sorted_locales().keys().copied().collect();
+        assert_eq!(sorted, vec!["de", "fr"]);
+    }
+
+    #[test]
+    fn desktop_entry_wm_class_version_and_actions() {
+        let mut name_localized = HashMap::new();
+        name_localized.insert("fr".to_string(), "Nouvelle fenetre".to_string());
+
+        let mut actions = HashMap::new();
+        actions.insert(
+            "new-window".to_string(),
+            DesktopAction {
+                name: "New Window".to_string(),
+                exec: Some("myapp --new-window".to_string()),
+                icon: Some("myapp-new".to_string()),
+                name_localized: Some(name_localized),
+            },
+        );
+        actions.insert(
+            "about".to_string(),
+            DesktopAction {
+                name: "About".to_string(),
+                exec: None,
+                icon: None,
+                name_localized: None,
+            },
+        );
+
+        let contents = render_desktop_entry(&DesktopEntryInput {
+            bin_name: "myapp",
+            app_name: "My App",
+            comment: "",
+            categories: Some("Utility;"),
+            exec_args: None,
+            use_terminal: false,
+            mime_types: &[],
+            localizations: None,
+            startup_wm_class: Some("myapp-window"),
+            appimage_version: Some("1.2.3"),
+            actions: Some(&actions),
+        });
+
+        assert!(contents.contains("StartupWMClass=myapp-window\n"));
+        assert!(contents.contains("X-AppImage-Version=1.2.3\n"));
+        assert!(contents.contains("Actions=about;new-window;\n"));
+        assert!(contents.contains("[Desktop Action about]\n"));
+        assert!(contents.contains("[Desktop Action new-window]\n"));
+        assert!(contents.contains("Name=New Window\n"));
+        assert!(contents.contains("Name[fr]=Nouvelle fenetre\n"));
+        assert!(contents.contains("Exec=myapp --new-window\n"));
+        assert!(contents.contains("Icon=myapp-new\n"));
+
+        // Action with no Exec falls back to the binary.
+        let about_group = contents.split("[Desktop Action about]").nth(1).unwrap();
+        assert!(about_group.contains("Exec=myapp\n"));
+
+        // The Actions list appears in the main group, before the action groups.
+        assert!(contents.find("Actions=").unwrap() < contents.find("[Desktop Action").unwrap());
+    }
+
+    #[test]
+    fn locale_encoding_part_is_stripped() {
+        let mut locs = HashMap::new();
+        locs.insert(
+            "fr.UTF-8".to_string(),
+            LinuxDesktopLocale {
+                icon: Some("myapp-fr".into()),
+                name: Some("Mon App".into()),
+                comment: None,
+                generic_name: None,
+                keywords: None,
+            },
+        );
+
+        let contents = render_desktop_entry(&DesktopEntryInput {
+            bin_name: "myapp",
+            app_name: "My App",
+            comment: "",
+            categories: None,
+            exec_args: None,
+            use_terminal: false,
+            mime_types: &[],
+            localizations: Some(LinuxDesktopLocalizations::new(&locs)),
+            startup_wm_class: None,
+            appimage_version: None,
+            actions: None,
+        });
+
+        assert!(contents.contains("Name[fr]=Mon App\n"));
+        assert!(contents.contains("Icon[fr]=myapp-fr\n"));
+        assert!(!contents.contains("fr.UTF-8"));
+    }
+}

--- a/src/bundle/linux/icons.rs
+++ b/src/bundle/linux/icons.rs
@@ -1,0 +1,109 @@
+//! FreeDesktop hicolor icon theme installation for Linux packages.
+
+use crate::bundle::{Settings, common};
+use image::GenericImageView;
+use std::collections::BTreeSet;
+use std::ffi::OsStr;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+
+/// A rendered icon's pixel dimensions plus whether it is a `@2x` high-density
+/// variant. Used to install each distinct size only once.
+type IconSize = (u32, u32, bool);
+
+/// Path of a hicolor themed PNG for one size, e.g.
+/// `<base>/128x128@2x/apps/<binary>.png`.
+fn hicolor_png_path(
+    base_directory: &Path,
+    binary_name: &str,
+    (width, height, high_density): IconSize,
+) -> PathBuf {
+    let density_suffix = if high_density { "@2x" } else { "" };
+    base_directory.join(format!(
+        "{width}x{height}{density_suffix}/apps/{binary_name}.png"
+    ))
+}
+
+/// Copy a source PNG into the theme, keyed by its dimensions so each size is
+/// installed only once.
+fn install_png_icon(
+    icon_path: &Path,
+    base_directory: &Path,
+    binary_name: &str,
+    seen_sizes: &mut BTreeSet<IconSize>,
+) -> crate::Result<()> {
+    let image = image::ImageReader::open(icon_path)?
+        .with_guessed_format()?
+        .decode()?;
+    let (width, height) = image.dimensions();
+    let size = (width, height, common::is_retina(icon_path));
+
+    if seen_sizes.insert(size) {
+        common::copy_file(
+            icon_path,
+            &hicolor_png_path(base_directory, binary_name, size),
+        )?;
+    }
+    Ok(())
+}
+
+/// Install an ICNS family (one PNG per contained size) or any other raster
+/// format (re-encoded to a single PNG).
+fn install_other_icon(
+    icon_path: &Path,
+    base_directory: &Path,
+    binary_name: &str,
+    seen_sizes: &mut BTreeSet<IconSize>,
+) -> crate::Result<()> {
+    if icon_path.extension() == Some(OsStr::new("icns")) {
+        let icon_family = icns::IconFamily::read(File::open(icon_path)?)?;
+        for icon_type in icon_family.available_icons() {
+            let size = (
+                icon_type.screen_width(),
+                icon_type.screen_height(),
+                icon_type.pixel_density() > 1,
+            );
+            if seen_sizes.insert(size) {
+                let icon = icon_family.get_icon_with_type(icon_type)?;
+                let destination = hicolor_png_path(base_directory, binary_name, size);
+                icon.write_png(common::create_file(&destination)?)?;
+            }
+        }
+    } else {
+        let icon = image::open(icon_path)?;
+        let (width, height) = icon.dimensions();
+        let size = (width, height, common::is_retina(icon_path));
+        if seen_sizes.insert(size) {
+            let destination = hicolor_png_path(base_directory, binary_name, size);
+            icon.write_to(
+                &mut common::create_file(&destination)?,
+                image::ImageFormat::Png,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+/// Generate the icon files and store them under the `data_dir`.
+pub fn generate_icon_files(settings: &Settings, data_dir: &Path) -> crate::Result<()> {
+    let base_directory = data_dir.join("usr/share/icons/hicolor");
+    let binary_name = settings.binary_name();
+    let mut seen_sizes = BTreeSet::new();
+
+    for icon_path in settings.icon_files() {
+        let icon_path = icon_path?;
+        match icon_path.extension().and_then(OsStr::to_str) {
+            Some("svg") => {
+                let scalable_directory = base_directory.join("scalable/apps");
+                std::fs::create_dir_all(&scalable_directory)?;
+                let destination = scalable_directory.join(format!("{binary_name}.svg"));
+                common::copy_file(&icon_path, &destination)?;
+            }
+            Some("png") => {
+                install_png_icon(&icon_path, &base_directory, binary_name, &mut seen_sizes)?;
+            }
+            _ => install_other_icon(&icon_path, &base_directory, binary_name, &mut seen_sizes)?,
+        }
+    }
+    Ok(())
+}

--- a/src/bundle/linux/mod.rs
+++ b/src/bundle/linux/mod.rs
@@ -1,4 +1,11 @@
 pub(crate) mod appimage_bundle;
 mod common;
 pub(crate) mod deb_bundle;
+mod desktop;
+mod icons;
 pub(crate) mod rpm_bundle;
+
+// Re-export helpers used by deb/appimage packages.
+pub(crate) use common::{create_file_with_data, generate_md5sum, tar_and_gzip_dir, total_dir_size};
+pub(crate) use desktop::{DesktopFileOptions, generate_desktop_file};
+pub(crate) use icons::generate_icon_files;

--- a/src/bundle/localization/linux.rs
+++ b/src/bundle/localization/linux.rs
@@ -1,0 +1,341 @@
+//! FreeDesktop `.desktop` file localization.
+
+use super::{FALLBACK_LOCALE_PREFERENCE, sorted_locales};
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::fmt::Write as _;
+
+/// Keywords for a FreeDesktop `.desktop` entry (`localestring(s)`).
+///
+/// Accepts either a semicolon-separated string or a TOML list of strings.
+/// Lists are joined with `;` and terminated with a trailing `;` per the
+/// [Desktop Entry Spec](https://specifications.freedesktop.org/desktop-entry-spec/latest/).
+#[derive(Clone, Debug, serde::Deserialize)]
+#[serde(untagged)]
+pub enum DesktopKeywords {
+    String(String),
+    List(Vec<String>),
+}
+
+/// Per-locale FreeDesktop desktop-entry strings.
+///
+/// TOML keys use FreeDesktop names (`Name`, `GenericName`, `Comment`, `Keywords`)
+/// so the manifest mirrors the generated desktop file. Only `localestring` keys
+/// are supported here; non-localizable keys (`Exec`, `Icon`, …) stay global.
+#[derive(Clone, Debug, Default, serde::Deserialize)]
+pub struct LinuxDesktopLocale {
+    #[serde(rename = "Name", default)]
+    pub name: Option<String>,
+    #[serde(rename = "GenericName", default)]
+    pub generic_name: Option<String>,
+    #[serde(rename = "Comment", default)]
+    pub comment: Option<String>,
+    #[serde(rename = "Keywords", default)]
+    pub keywords: Option<DesktopKeywords>,
+    /// Localized icon.
+    #[serde(rename = "Icon", default)]
+    pub icon: Option<String>,
+}
+
+/// Locale-keyed FreeDesktop desktop strings for Linux packages.
+#[derive(Clone, Copy, Debug)]
+pub struct LinuxDesktopLocalizations<'a> {
+    locale_mapping: &'a HashMap<String, LinuxDesktopLocale>,
+}
+
+impl<'a> LinuxDesktopLocalizations<'a> {
+    pub fn new(locale_mapping: &'a HashMap<String, LinuxDesktopLocale>) -> Self {
+        Self { locale_mapping }
+    }
+
+    /// Locales sorted by code for deterministic artifact output.
+    pub fn sorted_locales(&self) -> std::collections::BTreeMap<&'a str, &'a LinuxDesktopLocale> {
+        sorted_locales(self.locale_mapping)
+    }
+
+    /// Look up a non-empty string field with `C` to `en` to first-sorted-locale fallback.
+    pub fn fallback_string<F>(&self, extract_field: F) -> Option<&str>
+    where
+        F: Fn(&'a LinuxDesktopLocale) -> Option<&'a str>,
+    {
+        self.fallback(|locale_data| extract_field(locale_data).filter(|string| !string.is_empty()))
+    }
+
+    /// Generic fallback: walk C to en to first-sorted-locale, return first `Some`.
+    fn fallback<T: ?Sized>(
+        &self,
+        extract_field: impl Fn(&'a LinuxDesktopLocale) -> Option<&'a T>,
+    ) -> Option<&'a T> {
+        FALLBACK_LOCALE_PREFERENCE
+            .iter()
+            .find_map(|preferred_locale| {
+                self.locale_mapping
+                    .get(*preferred_locale)
+                    .and_then(&extract_field)
+            })
+            .or_else(move || {
+                self.sorted_locales()
+                    .values()
+                    .find_map(|locale_data| extract_field(locale_data))
+            })
+    }
+
+    /// Look up Keywords with the same fallback preference as string fields.
+    pub fn fallback_keywords(&self) -> Option<&DesktopKeywords> {
+        self.fallback(|locale_data| locale_data.keywords.as_ref())
+    }
+
+    /// Append FreeDesktop localized keys (`Name[fr]=…`, …) and any unlocalized
+    /// `GenericName` / `Keywords` bases required by the Desktop Entry Spec.
+    pub fn append_desktop_keys(&self, output_buffer: &mut String) {
+        self.append_base_generic_name(output_buffer);
+        self.append_base_keywords(output_buffer);
+        self.append_localized_entries(output_buffer);
+    }
+
+    fn append_base_generic_name(&self, output_buffer: &mut String) {
+        let has_localized_generic = self.locale_mapping.values().any(|locale_data| {
+            locale_data
+                .generic_name
+                .as_ref()
+                .is_some_and(|name| !name.is_empty())
+        });
+
+        if has_localized_generic {
+            if let Some(fallback_name) =
+                self.fallback_string(|locale_data| locale_data.generic_name.as_deref())
+            {
+                let _ = writeln!(
+                    output_buffer,
+                    "GenericName={}",
+                    escape_desktop_value(fallback_name)
+                );
+            }
+        }
+    }
+
+    fn append_base_keywords(&self, output_buffer: &mut String) {
+        let has_localized_keywords = self
+            .locale_mapping
+            .values()
+            .any(|locale_data| locale_data.keywords.is_some());
+
+        if has_localized_keywords {
+            if let Some(fallback_keywords) = self.fallback_keywords() {
+                let _ = writeln!(
+                    output_buffer,
+                    "Keywords={}",
+                    format_keywords_value(fallback_keywords)
+                );
+            }
+        }
+    }
+
+    fn append_localized_entries(&self, output_buffer: &mut String) {
+        for (locale_code, locale_data) in self.sorted_locales() {
+            self.append_single_localized_entry(
+                output_buffer,
+                "Name",
+                locale_code,
+                locale_data.name.as_deref(),
+            );
+            self.append_single_localized_entry(
+                output_buffer,
+                "GenericName",
+                locale_code,
+                locale_data.generic_name.as_deref(),
+            );
+            self.append_single_localized_entry(
+                output_buffer,
+                "Comment",
+                locale_code,
+                locale_data.comment.as_deref(),
+            );
+
+            if let Some(keywords) = locale_data.keywords.as_ref() {
+                let _ = writeln!(
+                    output_buffer,
+                    "Keywords[{locale_code}]={}",
+                    format_keywords_value(keywords)
+                );
+            }
+
+            self.append_single_localized_entry(
+                output_buffer,
+                "Icon",
+                locale_code,
+                locale_data.icon.as_deref(),
+            );
+        }
+    }
+
+    fn append_single_localized_entry(
+        &self,
+        output_buffer: &mut String,
+        key: &str,
+        locale_code: &str,
+        value: Option<&str>,
+    ) {
+        if let Some(valid_string) = value.filter(|string| !string.is_empty()) {
+            let _ = writeln!(
+                output_buffer,
+                "{key}[{locale_code}]={}",
+                escape_desktop_value(valid_string)
+            );
+        }
+    }
+
+    /// Whether any locale provides a non-empty Comment.
+    pub fn has_localized_comment(&self) -> bool {
+        self.locale_mapping.values().any(|locale_data| {
+            locale_data
+                .comment
+                .as_ref()
+                .is_some_and(|comment| !comment.is_empty())
+        })
+    }
+
+    /// Fallback Comment when the unlocalized base is empty but localizations exist.
+    pub fn fallback_comment(&self) -> Option<&str> {
+        self.fallback_string(|locale_data| locale_data.comment.as_deref())
+    }
+}
+
+/// Escape a FreeDesktop desktop-entry value of type `string` / `localestring`.
+pub fn escape_desktop_value(value: &str) -> Cow<'_, str> {
+    if !value.contains(['\\', '\n', '\r', '\t']) {
+        return Cow::Borrowed(value);
+    }
+
+    let mut escaped_string = String::with_capacity(value.len() + 4);
+    for character in value.chars() {
+        match character {
+            '\\' => escaped_string.push_str(r"\\"),
+            '\n' => escaped_string.push_str(r"\n"),
+            '\r' => escaped_string.push_str(r"\r"),
+            '\t' => escaped_string.push_str(r"\t"),
+            _ => escaped_string.push(character),
+        }
+    }
+    Cow::Owned(escaped_string)
+}
+
+/// Escape a single item inside a FreeDesktop `string(s)` / `localestring(s)` list.
+fn escape_desktop_list_item(value: &str) -> Cow<'_, str> {
+    let escaped_value = escape_desktop_value(value);
+    if escaped_value.contains(';') {
+        Cow::Owned(escaped_value.replace(';', r"\;"))
+    } else {
+        escaped_value
+    }
+}
+
+/// Format a Keywords desktop value, applying escapes and standardizing structure.
+pub fn format_keywords_value(keywords: &DesktopKeywords) -> String {
+    match keywords {
+        DesktopKeywords::String(keyword_string) => {
+            let escaped_string = escape_desktop_value(keyword_string);
+            if !escaped_string.is_empty() && !escaped_string.ends_with(';') {
+                let mut string_with_semicolon = escaped_string.into_owned();
+                string_with_semicolon.push(';');
+                string_with_semicolon
+            } else {
+                escaped_string.into_owned()
+            }
+        }
+        DesktopKeywords::List(keyword_list) => {
+            let mut formatted_keywords = String::new();
+            for item in keyword_list {
+                formatted_keywords.push_str(&escape_desktop_list_item(item));
+                formatted_keywords.push(';');
+            }
+            formatted_keywords
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escape_desktop_value_escapes_specials() {
+        assert_eq!(escape_desktop_value(r"a\b"), r"a\\b");
+        assert_eq!(escape_desktop_value("line\nbreak"), r"line\nbreak");
+        assert_eq!(escape_desktop_value("tab\there"), r"tab\there");
+        assert_eq!(escape_desktop_value("ret\rurn"), r"ret\rurn");
+    }
+
+    #[test]
+    fn append_desktop_keys_sorted_locales() {
+        let mut locale_mapping = HashMap::new();
+        locale_mapping.insert(
+            "fr".to_string(),
+            LinuxDesktopLocale {
+                icon: None,
+                name: Some("Mon App".into()),
+                comment: Some("Une description".into()),
+                generic_name: Some("Utilitaire".into()),
+                keywords: Some(DesktopKeywords::List(vec![
+                    "outil".into(),
+                    "utilitaire".into(),
+                ])),
+            },
+        );
+        locale_mapping.insert(
+            "de".to_string(),
+            LinuxDesktopLocale {
+                icon: None,
+                name: Some("Meine App".into()),
+                comment: Some("Eine Beschreibung".into()),
+                generic_name: Some("Dienstprogramm".into()),
+                keywords: Some(DesktopKeywords::String("werkzeug;dienstprogramm".into())),
+            },
+        );
+
+        let localizations = LinuxDesktopLocalizations::new(&locale_mapping);
+        let mut output_buffer = String::new();
+        localizations.append_desktop_keys(&mut output_buffer);
+
+        assert!(output_buffer.contains("GenericName=Dienstprogramm\n"));
+        assert!(output_buffer.contains("Keywords=werkzeug;dienstprogramm;\n"));
+        assert!(output_buffer.contains("Name[de]=Meine App\n"));
+        assert!(output_buffer.contains("Name[fr]=Mon App\n"));
+
+        let de_position = output_buffer.find("Name[de]=").unwrap();
+        let fr_position = output_buffer.find("Name[fr]=").unwrap();
+        assert!(de_position < fr_position);
+    }
+
+    #[test]
+    fn fallback_prefers_en_over_first_sorted() {
+        let mut locale_mapping = HashMap::new();
+        locale_mapping.insert(
+            "fr".to_string(),
+            LinuxDesktopLocale {
+                icon: None,
+                generic_name: Some("Utilitaire".into()),
+                ..Default::default()
+            },
+        );
+        locale_mapping.insert(
+            "en".to_string(),
+            LinuxDesktopLocale {
+                icon: None,
+                generic_name: Some("Utility".into()),
+                ..Default::default()
+            },
+        );
+        let localizations = LinuxDesktopLocalizations::new(&locale_mapping);
+        assert_eq!(
+            localizations.fallback_string(|locale_data| locale_data.generic_name.as_deref()),
+            Some("Utility")
+        );
+    }
+
+    #[test]
+    fn keywords_escape_embedded_semicolons() {
+        let keywords = DesktopKeywords::List(vec!["a;b".into(), "c".into()]);
+        assert_eq!(format_keywords_value(&keywords), r"a\;b;c;");
+    }
+}

--- a/src/bundle/localization/linux.rs
+++ b/src/bundle/localization/linux.rs
@@ -101,16 +101,15 @@ impl<'a> LinuxDesktopLocalizations<'a> {
                 .is_some_and(|name| !name.is_empty())
         });
 
-        if has_localized_generic {
-            if let Some(fallback_name) =
+        if has_localized_generic
+            && let Some(fallback_name) =
                 self.fallback_string(|locale_data| locale_data.generic_name.as_deref())
-            {
-                let _ = writeln!(
-                    output_buffer,
-                    "GenericName={}",
-                    escape_desktop_value(fallback_name)
-                );
-            }
+        {
+            let _ = writeln!(
+                output_buffer,
+                "GenericName={}",
+                escape_desktop_value(fallback_name)
+            );
         }
     }
 
@@ -120,14 +119,12 @@ impl<'a> LinuxDesktopLocalizations<'a> {
             .values()
             .any(|locale_data| locale_data.keywords.is_some());
 
-        if has_localized_keywords {
-            if let Some(fallback_keywords) = self.fallback_keywords() {
-                let _ = writeln!(
-                    output_buffer,
-                    "Keywords={}",
-                    format_keywords_value(fallback_keywords)
-                );
-            }
+        if has_localized_keywords && let Some(fallback_keywords) = self.fallback_keywords() {
+            let _ = writeln!(
+                output_buffer,
+                "Keywords={}",
+                format_keywords_value(fallback_keywords)
+            );
         }
     }
 

--- a/src/bundle/localization/mod.rs
+++ b/src/bundle/localization/mod.rs
@@ -1,0 +1,49 @@
+//! Shared localization API for platform bundles.
+//!
+//! Cargo.toml stores locale tables as:
+//!
+//! ```toml
+//! [package.metadata.bundle.osx_localizations.fr]
+//! CFBundleDisplayName = "Mon Application"
+//!
+//! [package.metadata.bundle.linux_localizations.fr]
+//! Name = "Mon App"
+//! Comment = "Une description"
+//! ```
+//!
+//! Both shapes are a locale-code → platform-specific strings map. Platform
+//! writers wrap that map and expose methods directly as inherent implementations.
+
+mod linux;
+mod osx;
+
+pub use linux::{LinuxDesktopLocale, LinuxDesktopLocalizations};
+pub use osx::OsxLocalizations;
+
+// Re-exported for unit tests and any future desktop-entry helpers.
+#[cfg(test)]
+pub use linux::DesktopKeywords;
+
+// Used by the FreeDesktop desktop-file renderer.
+pub(crate) use linux::escape_desktop_value;
+
+use std::collections::{BTreeMap, HashMap};
+
+/// Locales sorted by code for deterministic artifact output.
+pub(crate) fn sorted_locales<E>(map: &HashMap<String, E>) -> BTreeMap<&str, &E> {
+    map.iter()
+        .map(|(locale, entry)| (strip_locale_encoding(locale), entry))
+        .collect()
+}
+
+/// Strip a `.ENCODING` component from a locale code, preserving any
+/// `@MODIFIER` suffix.
+fn strip_locale_encoding(locale: &str) -> &str {
+    match locale.split_once('.') {
+        Some((prefix, rest)) if !rest.contains('@') => prefix,
+        _ => locale,
+    }
+}
+
+/// Preferred fallback locales when a platform needs an unlocalized base value.
+pub(crate) const FALLBACK_LOCALE_PREFERENCE: &[&str] = &["C", "en"];

--- a/src/bundle/localization/osx.rs
+++ b/src/bundle/localization/osx.rs
@@ -1,0 +1,158 @@
+//! macOS `*.lproj/InfoPlist.strings` localization.
+
+use super::sorted_locales;
+use crate::bundle::common;
+use anyhow::Context;
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+/// Locale-keyed InfoPlist string tables for macOS app bundles.
+///
+/// Mirrors the Cargo.toml shape:
+///
+/// ```toml
+/// [package.metadata.bundle.osx_localizations.fr]
+/// CFBundleDisplayName = "Mon Application"
+/// ```
+#[derive(Clone, Copy, Debug)]
+pub struct OsxLocalizations<'a> {
+    localized_strings: &'a HashMap<String, HashMap<String, String>>,
+}
+
+impl<'a> OsxLocalizations<'a> {
+    pub fn new(localized_strings: &'a HashMap<String, HashMap<String, String>>) -> Self {
+        Self { localized_strings }
+    }
+
+    /// Writes `*.lproj/InfoPlist.strings` under the provided `output_root`
+    /// (typically `Contents/Resources`).
+    pub fn write_to_directory(&self, output_root: &Path) -> crate::Result<()> {
+        for (locale_code, strings_mapping) in sorted_locales(self.localized_strings) {
+            self.write_single_locale_directory(output_root, locale_code, strings_mapping)?;
+        }
+        Ok(())
+    }
+
+    /// Handles the directory creation and file initialization for a single locale.
+    fn write_single_locale_directory(
+        &self,
+        output_root: &Path,
+        locale_code: &str,
+        strings_mapping: &HashMap<String, String>,
+    ) -> crate::Result<()> {
+        let localization_directory = output_root.join(locale_code).with_extension("lproj");
+
+        fs::create_dir_all(&localization_directory).with_context(|| {
+            format!("Failed to create localization directory at {localization_directory:?}")
+        })?;
+
+        let strings_file_path = localization_directory.join("InfoPlist.strings");
+        let mut output_file = common::create_file(&strings_file_path)?;
+
+        Self::write_key_value_pairs(&mut output_file, strings_mapping)?;
+        output_file.flush()?;
+
+        Ok(())
+    }
+
+    /// Formats and writes the specific key-value string pairs into the target file.
+    fn write_key_value_pairs(
+        output_file: &mut impl Write,
+        strings_mapping: &HashMap<String, String>,
+    ) -> crate::Result<()> {
+        for (key, value) in strings_mapping {
+            writeln!(
+                output_file,
+                "{key} = \"{}\";",
+                escape_legacy_apple_string(value)
+            )?;
+        }
+        Ok(())
+    }
+}
+
+/// Escapes embedded backslashes and double-quotes for the legacy `.strings` file format.
+fn escape_legacy_apple_string(value: &str) -> Cow<'_, str> {
+    if !value.contains(['\\', '"']) {
+        return Cow::Borrowed(value);
+    }
+
+    let mut escaped_string = String::with_capacity(value.len() + 2);
+    for character in value.chars() {
+        match character {
+            '\\' => escaped_string.push_str(r"\\"),
+            '"' => escaped_string.push_str(r#"\""#),
+            _ => escaped_string.push(character),
+        }
+    }
+    Cow::Owned(escaped_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn write_to_directory_creates_lproj_strings() {
+        let mut localized_strings = HashMap::new();
+        localized_strings.insert(
+            "fr".to_string(),
+            HashMap::from([("CFBundleDisplayName".into(), "Mon Application".into())]),
+        );
+        localized_strings.insert(
+            "de".to_string(),
+            HashMap::from([("CFBundleDisplayName".into(), "Meine Anwendung".into())]),
+        );
+
+        let localizations = OsxLocalizations::new(&localized_strings);
+        let temporary_directory = tempdir().unwrap();
+
+        localizations
+            .write_to_directory(temporary_directory.path())
+            .unwrap();
+
+        let french_output = std::fs::read_to_string(
+            temporary_directory
+                .path()
+                .join("fr.lproj/InfoPlist.strings"),
+        )
+        .unwrap();
+        assert!(french_output.contains(r#"CFBundleDisplayName = "Mon Application";"#));
+
+        let german_output = std::fs::read_to_string(
+            temporary_directory
+                .path()
+                .join("de.lproj/InfoPlist.strings"),
+        )
+        .unwrap();
+        assert!(german_output.contains(r#"CFBundleDisplayName = "Meine Anwendung";"#));
+    }
+
+    #[test]
+    fn write_to_directory_escapes_quotes() {
+        let mut localized_strings = HashMap::new();
+        localized_strings.insert(
+            "en".to_string(),
+            HashMap::from([("CFBundleName".into(), r#"Say "hi""#.into())]),
+        );
+
+        let localizations = OsxLocalizations::new(&localized_strings);
+        let temporary_directory = tempdir().unwrap();
+
+        localizations
+            .write_to_directory(temporary_directory.path())
+            .unwrap();
+
+        let english_output = std::fs::read_to_string(
+            temporary_directory
+                .path()
+                .join("en.lproj/InfoPlist.strings"),
+        )
+        .unwrap();
+        assert!(english_output.contains(r#"CFBundleName = "Say \"hi\"";"#));
+    }
+}

--- a/src/bundle/mod.rs
+++ b/src/bundle/mod.rs
@@ -3,6 +3,7 @@ mod common;
 mod dmg_bundle;
 mod ios_bundle;
 mod linux;
+mod localization;
 mod msi_bundle;
 mod osx_bundle;
 mod settings;

--- a/src/bundle/osx_bundle.rs
+++ b/src/bundle/osx_bundle.rs
@@ -75,8 +75,11 @@ pub fn bundle_project_at(settings: &Settings, output_dir: &Path) -> crate::Resul
     copy_binary_to_bundle(&bundle_directory, settings)
         .with_context(|| format!("Failed to copy binary from {:?}", settings.binary_path()))?;
 
-    write_localizations(&resources_dir, settings)
-        .with_context(|| "Failed to write localisation files")?;
+    if let Some(localizations) = settings.osx_localizations() {
+        localizations
+            .write_to_directory(&resources_dir)
+            .with_context(|| "Failed to write localisation files")?;
+    }
 
     if copied > 0 {
         add_rpath(&bundle_directory, settings)?;
@@ -541,31 +544,6 @@ fn create_icns_from_svg(
     family
         .write(icns_file)
         .with_context(|| format!("Failed to write ICNS file to {dest_path:?}"))?;
-
-    Ok(())
-}
-
-/// Writes `*.lproj/InfoPlist.strings` localisation files into `resources_dir`
-/// for every locale present in the settings' `osx_localizations` map.
-fn write_localizations(resources_dir: &Path, settings: &Settings) -> crate::Result<()> {
-    let Some(localizations) = settings.osx_localizations() else {
-        return Ok(());
-    };
-
-    for (locale, strings) in localizations {
-        let lproj_dir = resources_dir.join(locale).with_extension("lproj");
-        fs::create_dir_all(&lproj_dir)
-            .with_context(|| format!("Failed to create {lproj_dir:?}"))?;
-
-        let strings_path = lproj_dir.join("InfoPlist.strings");
-        let file = &mut common::create_file(&strings_path)?;
-        for (key, value) in strings {
-            // Escape embedded double-quotes in the value.
-            let escaped = value.replace('\\', "\\\\").replace('"', "\\\"");
-            writeln!(file, "{key} = \"{escaped}\";")?;
-        }
-        file.flush()?;
-    }
 
     Ok(())
 }

--- a/src/bundle/osx_bundle.rs
+++ b/src/bundle/osx_bundle.rs
@@ -93,74 +93,31 @@ struct DylibInfo {
 }
 
 impl DylibInfo {
+    /// Inspect a Mach-O binary's load commands for linked dylibs and rpaths.
     fn inspect(dylib_path: &Path) -> crate::Result<Self> {
-        use std::process::Command;
-        let out = Command::new("otool").arg("-l").arg(dylib_path).output()?;
+        use goblin::mach::{Mach, SingleArch};
 
-        if !out.status.success() {
-            anyhow::bail!("otool command failed with status: {}", out.status);
-        }
+        let bytes = std::fs::read(dylib_path)
+            .with_context(|| format!("Failed to read {}", dylib_path.display()))?;
 
-        let mut dylibs = Vec::new();
-        let mut rpaths = Vec::new();
-        enum NextAction {
-            Unknown,
-            FindDylib,
-            FindRpath,
-        }
-
-        let mut next_action = NextAction::Unknown;
-
-        let lines = String::from_utf8_lossy(&out.stdout);
-        for line in lines.lines() {
-            if let Some((w0, w1)) = line.trim_start().split_once(" ") {
-                match next_action {
-                    NextAction::Unknown => {
-                        if w0 == "cmd" {
-                            if w1 == "LC_LOAD_DYLIB" {
-                                next_action = NextAction::FindDylib;
-                            } else if w1 == "LC_RPATH" {
-                                next_action = NextAction::FindRpath;
-                            }
-                        }
-                    }
-                    NextAction::FindDylib => {
-                        if w0 == "name" {
-                            dylibs.push(Self::extract_path_from_line(w1, "name", "LC_LOAD_DYLIB")?);
-                            next_action = NextAction::Unknown;
-                        } else if w0 == "Load" {
-                            next_action = NextAction::Unknown; //just to avoid unexpected output
-                        }
-                    }
-                    NextAction::FindRpath => {
-                        if w0 == "path" {
-                            rpaths.push(Self::extract_path_from_line(w1, "path", "LC_RPATH")?);
-                            next_action = NextAction::Unknown;
-                        } else if w0 == "Load" {
-                            next_action = NextAction::Unknown; //just to avoid unexpected output
-                        }
+        let mut info = Self::default();
+        match Mach::parse(&bytes)? {
+            Mach::Binary(macho) => info.absorb(&macho),
+            Mach::Fat(fat) => {
+                for architecture in fat.into_iter() {
+                    if let SingleArch::MachO(macho) = architecture? {
+                        info.absorb(&macho);
                     }
                 }
             }
         }
-        Ok(Self { dylibs, rpaths })
+        Ok(info)
     }
 
-    fn extract_path_from_line(
-        line: &str,
-        field_name: &str,
-        context: &str,
-    ) -> crate::Result<PathBuf> {
-        if let Some(trail) = line.find('(') {
-            if trail > 0 {
-                let name = &line[..trail];
-                Ok(PathBuf::from(name.trim_end()))
-            } else {
-                anyhow::bail!("unexpected otool output - empty {field_name} field");
-            }
-        } else {
-            anyhow::bail!("unexpected otool output - expect {field_name} field after {context}");
-        }
+    /// Collect the linked dylibs and rpaths from one Mach-O architecture slice.
+    fn absorb(&mut self, macho: &goblin::mach::MachO) {
+        self.dylibs.extend(macho.libs.iter().map(PathBuf::from));
+        self.rpaths.extend(macho.rpaths.iter().map(PathBuf::from));
     }
 
     fn has_rpath<T: AsRef<Path>>(&self, path: T) -> bool {

--- a/src/bundle/settings.rs
+++ b/src/bundle/settings.rs
@@ -1,5 +1,6 @@
 use super::category::AppCategory;
 use super::common::print_warning;
+use super::localization::{LinuxDesktopLocale, LinuxDesktopLocalizations};
 use cargo_metadata::{Metadata, MetadataCommand, Package, TargetKind};
 use serde_json::Value;
 use std::borrow::Cow;
@@ -98,6 +99,26 @@ pub enum BuildArtifact {
     Example(String),
 }
 
+/// A single FreeDesktop desktop action.
+#[derive(Clone, Debug, Default, serde::Deserialize)]
+pub struct DesktopAction {
+    /// Localizable display name for the action (required by the spec).
+    #[serde(rename = "Name")]
+    pub name: String,
+
+    /// Command to execute; falls back to the app binary when absent.
+    #[serde(rename = "Exec", default)]
+    pub exec: Option<String>,
+
+    /// Icon for this action.
+    #[serde(rename = "Icon", default)]
+    pub icon: Option<String>,
+
+    /// Per-locale names.
+    #[serde(rename = "NameLocalized", default)]
+    pub name_localized: Option<HashMap<String, String>>, // local code to translation
+}
+
 #[derive(Clone, Debug, Default, serde::Deserialize)]
 struct BundleSettings {
     // General settings:
@@ -114,12 +135,22 @@ struct BundleSettings {
     linux_mime_types: Option<Vec<String>>,
     linux_exec_args: Option<String>,
     linux_use_terminal: Option<bool>,
+    /// Locale code → FreeDesktop localizable strings for `.desktop` files.
+    /// Mirrors `osx_localizations` shape: `[linux_localizations.fr] Name = "…"`.
+    /// Wrapped as [`LinuxDesktopLocalizations`] via [`Settings::linux_localizations`].
+    linux_localizations: Option<HashMap<String, LinuxDesktopLocale>>,
+    /// `StartupWMClass` value for the `.desktop` entry (Linux, all formats).
+    linux_startup_wm_class: Option<String>,
+    /// Named desktop actions emitted as `[Desktop Action <id>]` groups.
+    linux_desktop_actions: Option<HashMap<String, DesktopAction>>,
     deb_depends: Option<Vec<String>>,
     osx_frameworks: Option<Vec<String>>,
     osx_plugins: Option<Vec<String>>,
     osx_minimum_system_version: Option<String>,
     osx_url_schemes: Option<Vec<String>>,
     osx_info_plist_exts: Option<Vec<String>>,
+    /// Locale code → InfoPlist key/value strings for macOS `.lproj` files.
+    /// Wrapped as [`OsxLocalizations`] via [`Settings::osx_localizations`].
     osx_localizations: Option<HashMap<String, HashMap<String, String>>>,
     // Bundles for other binaries/examples:
     bin: Option<HashMap<String, BundleSettings>>,
@@ -535,6 +566,16 @@ impl Settings {
         self.bundle_settings.linux_exec_args.as_deref()
     }
 
+    /// `StartupWMClass` for the `.desktop` entry.
+    pub fn linux_startup_wm_class(&self) -> Option<&str> {
+        self.bundle_settings.linux_startup_wm_class.as_deref()
+    }
+
+    /// Desktop actions to emit as `[Desktop Action <id>]` groups.
+    pub fn linux_desktop_actions(&self) -> Option<&HashMap<String, DesktopAction>> {
+        self.bundle_settings.linux_desktop_actions.as_ref()
+    }
+
     pub fn osx_frameworks(&self) -> &[String] {
         match self.bundle_settings.osx_frameworks {
             Some(ref frameworks) => frameworks.as_slice(),
@@ -574,6 +615,18 @@ impl Settings {
     /// keys such as `"CFBundleDisplayName"` mapped to their translated value.
     pub fn osx_localizations(&self) -> Option<&HashMap<String, HashMap<String, String>>> {
         self.bundle_settings.osx_localizations.as_ref()
+    }
+
+    /// Linux desktop localizations as a [`LinuxDesktopLocalizations`] wrapper.
+    ///
+    /// Keys are inlined into the `.desktop` file as `Name[locale]=…` etc.
+    /// Unlocalized `Name` / `Comment` still come from
+    /// [`bundle_name`](Self::bundle_name) / [`short_description`](Self::short_description).
+    pub fn linux_localizations(&self) -> Option<LinuxDesktopLocalizations<'_>> {
+        self.bundle_settings
+            .linux_localizations
+            .as_ref()
+            .map(LinuxDesktopLocalizations::new)
     }
 }
 
@@ -664,6 +717,7 @@ impl Iterator for ResourcePaths<'_> {
 #[cfg(test)]
 mod tests {
     use super::{AppCategory, BundleSettings};
+    use crate::bundle::localization::DesktopKeywords;
 
     #[test]
     fn parse_cargo_toml() {
@@ -759,5 +813,47 @@ mod tests {
         let locs = bundle.osx_localizations.unwrap();
         assert_eq!(locs["fr"]["CFBundleDisplayName"], "Mon Application");
         assert_eq!(locs["de"]["CFBundleDisplayName"], "Meine Anwendung");
+    }
+
+    #[test]
+    fn linux_localizations_parses_from_toml() {
+        let toml_str = r#"
+            [linux_localizations.fr]
+            Name = "Mon App"
+            Comment = "Une description"
+            GenericName = "Utilitaire"
+            Keywords = ["outil", "utilitaire"]
+
+            [linux_localizations.de]
+            Name = "Meine App"
+            Comment = "Eine Beschreibung"
+            Keywords = "werkzeug;dienstprogramm"
+
+            [linux_localizations.pt_BR]
+            Name = "Meu App"
+            Comment = "Uma descrição"
+        "#;
+        let bundle: BundleSettings = toml::from_str(toml_str).unwrap();
+        let locs = bundle.linux_localizations.unwrap();
+
+        assert_eq!(locs["fr"].name.as_deref(), Some("Mon App"));
+        assert_eq!(locs["fr"].comment.as_deref(), Some("Une description"));
+        assert_eq!(locs["fr"].generic_name.as_deref(), Some("Utilitaire"));
+        match locs["fr"].keywords.as_ref().unwrap() {
+            DesktopKeywords::List(items) => {
+                assert_eq!(items, &["outil".to_string(), "utilitaire".to_string()]);
+            }
+            DesktopKeywords::String(_) => panic!("expected Keywords list for fr"),
+        }
+
+        assert_eq!(locs["de"].name.as_deref(), Some("Meine App"));
+        match locs["de"].keywords.as_ref().unwrap() {
+            DesktopKeywords::String(s) => assert_eq!(s, "werkzeug;dienstprogramm"),
+            DesktopKeywords::List(_) => panic!("expected Keywords string for de"),
+        }
+
+        assert_eq!(locs["pt_BR"].name.as_deref(), Some("Meu App"));
+        assert!(locs["pt_BR"].generic_name.is_none());
+        assert!(locs["pt_BR"].keywords.is_none());
     }
 }

--- a/src/bundle/settings.rs
+++ b/src/bundle/settings.rs
@@ -1,6 +1,6 @@
 use super::category::AppCategory;
 use super::common::print_warning;
-use super::localization::{LinuxDesktopLocale, LinuxDesktopLocalizations};
+use super::localization::{LinuxDesktopLocale, LinuxDesktopLocalizations, OsxLocalizations};
 use cargo_metadata::{Metadata, MetadataCommand, Package, TargetKind};
 use serde_json::Value;
 use std::borrow::Cow;
@@ -609,12 +609,14 @@ impl Settings {
         }
     }
 
-    /// Returns a map of locale codes to key-value localisation strings for
-    /// macOS `*.lproj/InfoPlist.strings` files.  The outer key is a locale
-    /// code such as `"fr"` or `"de"` and the inner map contains plist string
-    /// keys such as `"CFBundleDisplayName"` mapped to their translated value.
-    pub fn osx_localizations(&self) -> Option<&HashMap<String, HashMap<String, String>>> {
-        self.bundle_settings.osx_localizations.as_ref()
+    /// macOS localizations as an [`OsxLocalizations`] wrapper.
+    ///
+    /// Writes `*.lproj/InfoPlist.strings` under the Resources directory.
+    pub fn osx_localizations(&self) -> Option<OsxLocalizations<'_>> {
+        self.bundle_settings
+            .osx_localizations
+            .as_ref()
+            .map(OsxLocalizations::new)
     }
 
     /// Linux desktop localizations as a [`LinuxDesktopLocalizations`] wrapper.


### PR DESCRIPTION
The diff is so terribly large because of some requisite refactors that were befitting, now that Linux also has localization support. So now both mac and linux have very similar interfaces.

As part of these changes:
- Switched from our naive otool parsing to straight up goblin, which is a library I've become acquainted with recently that I think cleans things up a lot.
- Handles the spectrum of Linux install mechanisms, including generating .desktop files, installing hicolor icons, and of course localization.

All of this is documented in the edits within readme!

This will be the base for some other PRs I'm putting up!